### PR TITLE
Fixing numbering from text to numbers to maintain consistency

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -145,7 +145,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 4b3b) 2x2x2 Cube: The (random) state must require at least 4 moves to solve.
         - 4b3c) Pyraminx and Skewb: The (random) state must require at least 7 moves to solve.
         - 4b3d) Square-1: The (random) state must require at least 11 moves to solve.
-        - 4b3e) 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube, and Megaminx: sufficiently many random moves (instead of random state), at least two moves to solve.
+        - 4b3e) 5x5x5 Cube, 6x6x6 Cube, 7x7x7 Cube, and Megaminx: sufficiently many random moves (instead of random state), at least 2 moves to solve.
 - 4d) Scrambling orientation:
     - 4d1) NxNxN puzzles and Megaminx are scrambled beginning with the white face (if not possible, then the lightest face) on top and the green face (if not possible, then the darkest adjacent face) on the front.
     - 4d2) Pyraminx is scrambled beginning with the yellow face (if not possible, then the lightest face) on bottom and the green face (if not possible, then the darkest adjacent face) on the front.


### PR DESCRIPTION
Previous rules have numbering (4,7, 11), using '2' instead of 'two' maintains the consistency.
