### PR TITLE
updated URL for WRC contact page

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -23,7 +23,7 @@ WCA Regulations in [PDF format](wca-regulations-and-guidelines.pdf)
 Development of the WCA Regulations and Guidelines is public [on GitHub](https://github.com/cubing/wca-documents).
 
 ### Contact
-For questions and feedback, please contact the [WCA Regulations Committee (WRC)](http://www.worldcubeassociation.org/contact-information).
+For questions and feedback, please contact the [WCA Regulations Committee (WRC)](https://www.worldcubeassociation.org/contact/wrc).
 
 
 ## <contents> [Contents](regulations:contents)


### PR DESCRIPTION
Fixed the out of date URL for contacting the WRC.
