### PR TITLE
Fixes #344

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -191,6 +191,8 @@ To be more informative, each Guideline is classified using one of the following 
 - E2b+) [CLARIFICATION] A competitor may choose to stop an attempt early by handing in a solution before the time limit.
 - E2c+) [CLARIFICATION] Although the judge may provide a standard sheet for competitors to submit solutions, a competitor may submit a solution on a different piece of paper, as long as a single move sequence is unambiguously indicated as the submitted solution. (Note that the piece of paper must come from the judge, according to [Regulation E3a](regulations:regulation:E3a).)
 - E2c++) [CLARIFICATION] The competitor's solution must only use moves that are exactly defined in [Regulation 12a](regulations:regulation:12a). Examples of notation and moves that are not permitted in competition: [F], [R, U], [R: U], R'2, L'w, f, M, U2'.
+- E2e+) [CLARIFICATION] Competitors must not derive solutions from any part of the scramble sequence, and solutions should not share significant parts with the inverse scramble sequence.
+- E2e++) [EXAMPLE] Example of solutions that should result in a disqualification of the attempt (DNF): solutions beginning with the same 4 or more moves as the inverse scramble sequence.
 - E3b+) [REMINDER] "Rubik's Cube" refers only to the standard 3x3x3 puzzle.
 - E3d+) [CLARIFICATION] Any stopwatch or watch used by a competitor must not appear to have any functions that would help the competitor find a solution.
 - E3d++) [CLARIFICATION] Competitors should not consider a personal stopwatch or watch as the official time, and must submit their solution after the judge calls "STOP".

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -484,7 +484,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - E2c) At 60 minutes, each competitor must give the judge a legibly written solution with the competitor's name, using the notation defined for Outer Block Turn Metric (described in [Regulation 12a](regulations:regulation:12a)). Penalty: disqualification of the attempt (DNF).
     - E2d) The length of the solution is calculated in Outer Block Turn Metric (see [Regulation 12a](regulations:regulation:12a)).
         - E2d1) The competitor is permitted a maximum solution length of 80 (moves and rotations).
-    - E2e) The competitor's solution must not be directly derived from any part of the scrambling algorithm. Penalty: disqualification of the attempt (DNF).
+    - E2e) The competitor's solution must not be directly derived from any part of the scramble sequence. Penalty: disqualification of the attempt (DNF), at the discretion of the WCA Delegate.
         - E2e1) The WCA Delegate may ask the competitor to explain the purpose of each move in their solution, irrespective of scrambling algorithm. If the competitor cannot give a valid explanation, the attempt is disqualified (DNF).
 - E3) The competitor may use the following objects during the attempt. Penalty for using unauthorised objects: disqualification of the attempt (DNF).
     - E3a) Paper and pens (both supplied by judge).


### PR DESCRIPTION
See #344 for a longer explanation.

These changes clarify that E2e can also be relevant when there is no proof that a competitor used the scramble sequence to derive his solution intentionally.
With the new Fewest Moves scramble sequences implemented in TNoodle, starting a solution with the inverse of more than the last 4 moves of the scramble is a good evidence that the solution was derived from the scramble as the first and the last three moves of the scramble sequence are pointless. However, this is still a _"should"_, so in the rare case that beginning a solution with these moves is reasonable, this is not necessarily a DNF.

**Question**
Is "solutions beginning with more than 4 moves of the inverse scramble sequence" clear?
It can be interpreted that solutions should not begin with any 4 moves of the inverse scramble. But I have no idea how to clarify that here.
