### PR TITLE
Change almost all occurrences of "cubing" to "thewca" in light of the

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Regulations and Guidelines for official Rubik's Cube competitions sanctioned by the [World Cube Association](http://www.worldcubeassociation.org/).
 
-Official competitions must always use the current version of the Regulations at <https://www.worldcubeassociation.org/regulations/> (which matches the branch named [`official`](https://github.com/cubing/wca-regulations/tree/official) on GitHub).
+Official competitions must always use the current version of the Regulations at <https://www.worldcubeassociation.org/regulations/> (which matches the branch named [`official`](https://github.com/thewca/wca-regulations/tree/official) on GitHub).
 
-The current draft for upcoming Regulations is maintained on the branch named [`draft`](https://github.com/cubing/wca-regulations/tree/draft).
+The current draft for upcoming Regulations is maintained on the branch named [`draft`](https://github.com/thewca/wca-regulations/tree/draft).
 
 ## Translations
 
-See [`cubing/wca-regulations-translations`](https://github.com/cubing/wca-regulations-translations).
+See [`thewca/wca-regulations-translations`](https://github.com/thewca/wca-regulations-translations).

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -22,7 +22,7 @@ WCA Regulations in [PDF format](link:pdf)
 Development of the WCA Regulations and Guidelines is public [on GitHub](https://github.com/thewca/wca-regulations).
 
 ### Contact
-For questions and feedback, please contact the [WCA Regulations Committee (WRC)](https://www.worldcubeassociation.org/contact/wrc).
+For questions and feedback, please contact the [WCA Regulations Committee (WRC)](mailto:wrc@worldcubeassociation.org).
 
 
 ## <contents> [Contents](regulations:contents)

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -19,7 +19,7 @@ Original source of the WCA regulations: [www.worldcubeassociation.org/regulation
 WCA Regulations in [PDF format](link:pdf)
 
 ### Source
-Development of the WCA Regulations and Guidelines is public [on GitHub](https://github.com/cubing/wca-documents).
+Development of the WCA Regulations and Guidelines is public [on GitHub](https://github.com/thewca/wca-regulations).
 
 ### Contact
 For questions and feedback, please contact the [WCA Regulations Committee (WRC)](https://www.worldcubeassociation.org/contact/wrc).


### PR DESCRIPTION
github organization change.
