### PR TITLE
A4b) Change a slightly ambgiguous "them" to explicitly reference the competitor.

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -383,7 +383,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - A3d2) When 8 seconds of inspection have elapsed, the judge calls "8 SECONDS".
         - A3d3) When 12 seconds of inspection have elapsed, the judge calls "12 SECONDS".
 - A4) Starting the solve:
-    - A4b) The competitor uses their fingers to touch the elevated sensor surfaces of the timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to them. Penalty: time penalty (+2 seconds).
+    - A4b) The competitor uses their fingers to touch the elevated sensor surfaces of the timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to the competitor. Penalty: time penalty (+2 seconds).
         - A4b1) The competitor must have no physical contact with the puzzle between the inspection period and the start of the solve. Penalty: time penalty (+2 seconds).
     - A4d) If a Stackmat timer is in use, the competitor starts the solve by confirming that the timer light is green and then removing their hands from the timer (thus starting the timer).
         - A4d1) The competitor must start the solve within 15 seconds of the start of the inspection. Penalty: time penalty (+2 seconds).


### PR DESCRIPTION
@keemy pointed out to me that "them" can otherwise be interpreted as "palms", which would not carry the intended meaning. (We don't mean to say that the left palm must be on the left side and the right palm must be on the right side.)
