### PR TITLE
Updated the latest textual revision.

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -5,6 +5,8 @@
 
 ## Notes
 
+Latest textual revision: December 12, 2016
+
 ### WCA Regulations
 
 The WCA Guidelines supplement the [WCA Regulations](regulations:top). Please see the Regulations for more information about the WCA.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -5,6 +5,8 @@
 
 ## Notes
 
+Latest textual revision: December 12, 2016
+
 ### WCA Regulations and Guidelines
 
 The WCA Regulations contain the full set of Regulations that apply to all official competitions sanctioned by the World Cube Association.    


### PR DESCRIPTION
As per @lgarron's suggestion:

> We should follow the old convention and add "Last textual revision":
> https://www.worldcubeassociation.org/regulations/history/files/regulations2010.html
>

@jfly's fixes for contact link and a typo have actually been up since they were merged in `draft`, so we may as well just add this and merge current `draft` in `official`.