### PR TITLE
Tweaked language to allow for multiple official versions of the scrambling software.

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -161,7 +161,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 4d3) Square-1 is scrambled starting with the darker colour on front (out of the 2 possible scrambling orientations).
     - 4d4) Clock is scrambled starting with either side in front and 12 o'clock pointing up.
     - 4d5) Skewb is scrambled starting with the white face (if not possible, then the lightest face) on top and the green face (if not possible, then the darkest adjacent face) on the front-left.
-- 4f) Competition scramble sequences must be generated using the current official version of the official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
+- 4f) Competition scramble sequences must be generated using a current official version of the official WCA scramble program (available [via the WCA website](https://www.worldcubeassociation.org/regulations/scrambles/)).
 - 4g) After scrambling a puzzle, the scrambler must verify that the puzzle is scrambled correctly. If the puzzle state is wrong, the scrambler must correct it (e.g. by solving the puzzle and applying the scramble sequence again).
     - 4g1) Exception: For the 6x6x6 Cube, 7x7x7 Cube, and Megaminx, it is not necessary to correct the puzzle state, at the discretion of the WCA Delegate.
 


### PR DESCRIPTION
The motivation for this change is that new TNoodle versions with new features always get delayed for months because we don't like to mark new releases of TNoodle as official if they don't change the way scrambles are generated. However, we wrote TNoodle and the WCA API with this problem in mind, and as far as all our software is concerend, it is possible to have multiple official versions of TNoodle.

The current language still implies that there is only one official scrambling software program... maybe in some future we'll have multiple offical scrambling softwares, but I think it would be best to address that when it comes.