### PR TITLE
Fixing #417

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -43,7 +43,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 1c3) Sending the competition results to the WCA Results Team within one week of the end of the competition.
         - 1c3a) All scramble sequences used during a competition must be sent with the results of the competition.
         - 1c3b) Scramble sequences must be labelled with the events, rounds, and groups for which they were used.
-    - 1c4) Sending corrections to the competition results to the WCA Board.
+    - 1c4) Sending corrections to the competition results to the WCA Results Team.
     - 1c5) Advising the other officials where necessary.
     - 1c6) Approving all events and round formats of a competition, before the competition starts, and if changes are required during the competition.
     - 1c7) Decisions about disqualifying competitors during the competition.


### PR DESCRIPTION
I've changed 1c4 from:

> Sending corrections to the competition results to the WCA Board.

To:

> Sending corrections to the competition results to the WCA Results Team.

Credit goes to @pedrosino for noticing it :)