### PR TITLE
8a4: clarify announcement deadlines #415

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -111,7 +111,6 @@ To be more informative, each Guideline is classified using one of the following 
 
 ## <article-8><competitions><competitions> Article 8: Competitions
 
-- 8a4++) [RECOMMENDATION] The competition should be announced at least one month before the start of the competition.
 - 8a5+) [RECOMMENDATION] The competition should have at least 12 competitors.
 - 8a7+) [ADDITION] Organizers should strongly consider modifications to make Stackmat timers more robust against common incidents, such as making the buttons more difficult to press by accident (e.g. by attaching O-rings around the buttons) and securing the battery more firmly (e.g. by padding the battery compartment).
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -209,7 +209,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 8a1) Be approved by the WCA Board.
     - 8a2) Follow the WCA Regulations.
     - 8a3) Have a designated WCA Delegate in attendance.
-    - 8a4) Be announced on the WCA website at least two weeks before the start of the competition.
+    - 8a4) Be announced on the WCA website at least four weeks before the start of the competition. Exception: In special cases, competitions may be announced up to two weeks before, at the discretion of the WCA Board.
     - 8a6) Be publicly accessible.
     - 8a7) Use the authentic Speed Stacks Stackmat timer (Generation 2, Generation 3 Pro Timer, or Generation 4 Pro Timer) for time measurement.
     - 8a8) Be open to all who wish to compete. Restrictions must be approved by the WCA Board and clearly stated when the competition is announced.


### PR DESCRIPTION
Fixes #415

Note: I also removed the Guideline for 8a4 as it's no longer needed.