### PR TITLE
DNF for remaining attempts after disqualification. Fix #392.

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -91,6 +91,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
+        - 2j1a) The results of all remaining attempts in this event are recorded as DNF.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -91,7 +91,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
-        - 2j1a) The results of all remaining attempts in this event are recorded as DNF.
+        - 2j1a) The results of all remaining attempts in the event are recorded as DNF.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.


### PR DESCRIPTION
Motivation for DNF:
1) We have several cases in the past where results were recorded as DNF.
2) Introducing brand new result DQ can break every piece of code in the world that relies on DNF and DNS as the only ones being less than zero.