### PR TITLE
D1b: allow inspection with hands

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -185,6 +185,7 @@ To be more informative, each Guideline is classified using one of the following 
 ## <article-D><feet><solvingwithfeet> Article D: Solving With Feet
 
 - D1b+) [CLARIFICATION] The competitor may wear socks while solving.
+- D1b++) [CLARIFICATION] In the past, competitors were required to inspect the puzzle using their feet for Solving with Feet. They are now permitted to touch the puzzle with their hands or any other part of their body during inspection (see [Guideline A5b+](guidelines:guideline:A5b+)).
 - D1c+) [REMINDER] While repairing puzzle defects, other body parts must not touch the puzzle.
 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -467,7 +467,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 
 - D1) Standard speed solving procedures are followed, as described in [Article A](regulations:article:A) (Speed Solving). Additional regulations that supersede the corresponding procedures in [Article A](regulations:article:A) are described below.
     - D1a) During the attempt, the competitor must sit in a chair, sit on the surface, or stand.
-    - D1b) After starting the timer, the competitor must use only their feet and the surface to manipulate the puzzle. Penalty: disqualification of the attempt (DNF).
+    - D1b) During the solve, the competitor must use only their feet and the surface to manipulate the puzzle. Penalty: disqualification of the attempt (DNF).
 - D3) Starting the solve:
     - D3a) The competitor places their feet onto the timer sensors.
     - D3b) The competitor removes their feet from the timer sensors to start the solve.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -467,7 +467,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 
 - D1) Standard speed solving procedures are followed, as described in [Article A](regulations:article:A) (Speed Solving). Additional regulations that supersede the corresponding procedures in [Article A](regulations:article:A) are described below.
     - D1a) During the attempt, the competitor must sit in a chair, sit on the surface, or stand.
-    - D1b) During the attempt, the competitor must use only their feet and the surface to manipulate the puzzle. Penalty: disqualification of the attempt (DNF).
+    - D1b) After starting the timer, the competitor must use only their feet and the surface to manipulate the puzzle. Penalty: disqualification of the attempt (DNF).
 - D3) Starting the solve:
     - D3a) The competitor places their feet onto the timer sensors.
     - D3b) The competitor removes their feet from the timer sensors to start the solve.


### PR DESCRIPTION
Nobody complained in #460, so I am going ahead with my idea:
I changed D1b so that competitors must use their feet only after starting the timer, so inspection with hands is allowed.

As far as I can see, this change doesn't generate any loopholes:
- The inspection starts like in any other speedsolving event, competitors can pick up their cube or leave it on the mat and inspect with their feet like they could do in any other event.
- Starting the timer is defined in D3 and has to be done by placing the feet on the timer.
- Stopping is in D4.

