### PR TITLE
Add restrictions to Z4, #469

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -206,3 +206,8 @@ To be more informative, each Guideline is classified using one of the following 
 - H1b1++) [ADDITION] The judge may permit the competitor to continue the attempt unofficially, but the attempt must be stopped and judged first, in full accordance with the Regulations.
 - H1d+) [EXAMPLE] Example: Suppose a competitor attempts 10 cubes, stops the solve with a time of 59:57, and has two time penalties. The final result is 59:57 + 2*2 = 60:01 (also see [Regulation A1a5](regulations:regulation:A1a5)).
 - H1d++) [EXAMPLE] Example: Suppose a competitor attempts 10 cubes, the judge stops the competitor at 60 minutes, and the attempt has two time penalties. The final result is 60:00 + 2*2 = 60:04.
+
+
+## <article-Z><optional><optional> Article Z: Optional Regulations
+
+- Z4b+) [EXAMPLE] Examples for reasons which justify a change of the competitor limit after the competition was announced: the venue was changed or the number of registrations is higher than expected.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -521,5 +521,8 @@ Organization teams may adopt optional regulations to facilitate the administrati
 - Z1) The organization team may require competitors to submit puzzles during registration.
 - Z2) The organization team may limit the number of events per competitor.
 - Z3) The organization team may select competitors who directly qualify for certain rounds of certain events based on the results of specific previous competitions.
-- Z4) The organization team may limit the number of competitors per event or per competition, on either a "first come first serve" basis or based upon qualification results or rankings in the WCA world rankings of a previously announced calendar date.
+- Z4) The organization team may limit the number of competitors per event or per competition, on either a "first come first serve" basis or based upon qualification results or rankings in the WCA world rankings of a previously announced calendar date. If the number of competitors per event or per competition is limited, the following regulations apply:
+    - Z4a) If the limit for a competition or an event is reached before the competition, the organization team must not accept on-site registrations for the competition or the event.
+    - Z4b) Competitor limits should be announced together with the competition. Any changes to competitor limits are at the discretion of the WCA Board.
+    - Z4c) If there is more than one registration period, the organization team must announce each additional registration period at least 48 hours before it starts.
 - Z5) The organization team may prohibit competitors from participating in specific combinations of events.


### PR DESCRIPTION
First draft to fix #469 

I think the first two additions (Z4a + Z4b) are quite clear.

To explain the third a bit more:
It's a common approach to have two registration periods in China. Both of them are announced when the competition is announced. The second period is used to fill the spots of competitors who registered in the first period but canceled their registration.
I think that's not a bad approach as it makes the registration process transparent: people know that they will get a second chance to register and they know when this will happen.

For that reason, I decided against adding a stricter regulation reopening the registration.
In general, the main problem is that additional registration periods can currently be done in secret if an organizer just shares the news with his friends and no announcement is made. An announcement for 48 hours does not guarantee that everyone who is interested in registering knows of the additional registration period, but it gives everyone at least a chance.
