### PR TITLE
Clarify 'the delegate', fixes #499

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -32,6 +32,7 @@ To be more informative, each Guideline is classified using one of the following 
 
 ## <article-1><officials><officials> Article 1: Officials
 
+- 1c+) [CLARIFICATION] "The WCA Delegate" refers to anyone fulfilling the role of a WCA Delegate at a competition.
 - 1c3+) [RECOMMENDATION] Results should be ready at the end of the last day of competition.
 - 1c3++) [ADDITION] Physical records (e.g. score sheets, written solutions from Fewest Moves Solving) must be retained for a minimum of one month. Digital records (e.g. scramble sequences, results) must be retained permanently.
 - 1c3b+) [CLARIFICATION] If there are multiple groups, it is not necessary to identify which competitor was in which groups.


### PR DESCRIPTION
Do we need a further clarification that this is not only a clarification for 1c?
I think it's fine as 1c defines the responsibilities, so any other mention refers to 1c, but I'm also fine with adding one if someone has a good idea of the wording.