### PR TITLE
Forbid logos in blindfolded events and clarify 3k

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -75,6 +75,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 3j++) [CLARIFICATION] On Clock, pins must not be distinguishable from any other pin of the same side.
 - 3j2+) [CLARIFICATION] On Clock, all eighteen inner clock faces are considered similar pieces.
 - 3l+) [ADDITION] Logos may feature any reasonable design that does not give a conspicuous advantage (e.g. encoding information that could be used to cheat), and leave the colored part clearly recognizable. Unconventional logos are only permitted at the discretion of the WCA Delegate.
+- 3l++) [CLARIFICATION] In the past, puzzles with logos have been permitted for blindfolded events. Such puzzles are no longer permitted.
 
 
 ## <article-4><scrambling><scrambling> Article 4: Scrambling

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -133,8 +133,9 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 3j1) Puzzles are permitted to have reasonable wear, at the discretion of the WCA Delegate.
     - 3j2) Definition: Two pieces are similar to each other if they are identical in shape and size, or mirrored in shape and identical in size.
     - 3j3) Corrugated/textured parts which permit the orientation of pieces to be distinguished by feel are not permitted for blindfolded events.
-- 3k) Puzzles must be approved by the WCA Delegate before use in the competition.
-    - 3k1) If a puzzle is found to be not permitted during a round, the competitor must submit a replacement. Earlier results remain valid, at the discretion of the WCA Delegate.
+- 3k) Puzzles should be approved by the WCA Delegate before use in the competition.
+    - 3k1) If a puzzle is found to be not permitted during a round, the competitor must submit a replacement.
+    - 3k2) Penalty for attempts done with not permitted puzzles: disqualification of the attempt (DNF). Exception: If a puzzle is found to be not permitted during a round, earlier results may be replaced with an extra attempt, at the discretion of the WCA Delegate.
 - 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo. Exception: For blindfolded events, a puzzle must not have a logo.
     - 3l1) The logo must be placed on a center piece. Exceptions for puzzles that do not have center pieces:
         - 3l1a) For Pyraminx and 2x2x2, the logo may be on any piece.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -135,11 +135,11 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 3j3) Corrugated/textured parts which permit the orientation of pieces to be distinguished by feel are not permitted for blindfolded events.
 - 3k) Puzzles must be approved by the WCA Delegate before use in the competition.
     - 3k1) If a puzzle is found to be not permitted during a round, the competitor must submit a replacement. Earlier results remain valid, at the discretion of the WCA Delegate.
-- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo.
+- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo. Exception: For blindfolded events, a puzzle must not have a logo.
     - 3l1) The logo must be placed on a center piece. Exceptions for puzzles that do not have center pieces:
         - 3l1a) For Pyraminx and 2x2x2, the logo may be on any piece.
         - 3l1b) For Square-1, the logo must be on a piece in the equatorial slice.
-    - 3l2) The logo may be embossed, engraved, or consist of an overlay sticker. Exception: The logo must not be distinguishable by feel for blindfolded events (i.e. no embossings, engravings, or overlay stickers).
+    - 3l2) The logo may be embossed, engraved, or consist of an overlay sticker.
 - 3m) All brands of puzzles and puzzle parts are permitted, as long as the puzzles comply with all WCA Regulations.
 
 


### PR DESCRIPTION
As discussed in our email thread, here is a first draft:

- Changed 3l so that all logos for blindfolded events are forbidden.
- 3l2: Remove the exception for blindfolded events.
- 3k: 'must' -> 'should' to weaken the role of the delegate
- 3k1: Remove "Earlier results remain valid, at the discretion of the WCA Delegate."
- Add 3k2: define a penalty for attempts done with illegal cubes (DNF) and add an exception to grant extra attempts during a round.

Why?
The "distinguishable by feel"-exception has always been interpreted differently. Some delegates allow specific cubes, some don't. For example, the logo of the RSC has been discussed many times after WC17... 

Furthermore, it has always been interpreted as the responsibility of the delegate to check and approve puzzles. The regulations do not define a penalty for the use of illegal puzzles, so it might be not clear for competitors that they can be punished for using illegal puzzles. This makes it also difficult and painful to decide about incidents as the responsibility is shared between delegate and competitor. A clear definition of the penalty will hopefully solve this.

The WCA has been moving towards an "anything goes"-policy in the last 2-3 years and this change is pretty much the opposite. However, with the currently popular hardware that should not be a huge problem:
- Most puzzles have overlay stickers, which had to be removed with the prior regulations anyway.
- There are some stickerless puzzles with printed/embossed logos. These logos can be distinguished by feel, so they were also not allowed before.
- This is indeed a problem for competitors using individual stickers/logos, but this is clearly a minority.

