### PR TITLE
Specify that FMC pens may be self-supplied.

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -500,7 +500,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - E2e) The competitor's solution must not be directly derived from any part of the scramble sequence. Penalty: disqualification of the attempt (DNF), at the discretion of the WCA Delegate.
         - E2e1) The WCA Delegate may ask the competitor to explain the purpose of each move in their solution, irrespective of the scramble sequence. If the competitor cannot give a valid explanation, the attempt is disqualified (DNF).
 - E3) The competitor may use the following objects during the attempt. Penalty for using unauthorized objects: disqualification of the attempt (DNF).
-    - E3a) Paper and pens (both supplied by judge).
+    - E3a) Paper (supplied by the judge) and pens (supplied by the judge, or optionally self-supplied).
     - E3b) 3x3x3 Cubes (at most 3, self-supplied), as described in [Article 3](regulations:article:3).
     - E3c) Stickers (self-supplied).
     - E3d) Stopwatch or watch (self-supplied) for keeping track of the elapsed time, if it is approved by the WCA Delegate.


### PR DESCRIPTION
I believe this is already fairly common in practice, with the loophole that a competitor can ask a judge to "supply" their own pen to them. Since we already have 2k2 to handle cheating, I don't see a new risk in directly allowing this.

@julesDesjardin, could you review?