### PR TITLE
Clarify that individual non-permitted puzzles must count as unsolved in the total. (Followup to #670)

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -73,7 +73,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 3j++) [CLARIFICATION] On Clock, pins must not be distinguishable from any other pin of the same side.
 - 3j2+) [CLARIFICATION] On Clock, the nine inner clock faces on one side are considered similar pieces.
 - 3k2+) [ADDITION] The WCA Delegate should not apply a listed exception if they believe the competitor tried to use a non-permitted puzzle on purpose.
-- 3k2b+) [EXAMPLE] Suppose the competitor attempts 10 puzzles and solves 8 successfully. If it is found that two solved puzzles and one unsolved puzzle are not permitted, the competitor is considered to have solved 6 puzzles, at the discretion of the WCA Delegate.
+- 3k2b+) [EXAMPLE] Suppose the competitor attempts 10 puzzles and solves 8 successfully. If it is found that two solved puzzles and one unsolved puzzle are not permitted, the competitor is considered to have a result with 6 solved puzzles out of 10 (rather than DNF), at the discretion of the WCA Delegate.
 - 3l+) [ADDITION] Logos may feature any reasonable design that does not give a conspicuous advantage (e.g. encoding information that could be used to cheat), and leave the colored part clearly recognizable. Unconventional logos are only permitted at the discretion of the WCA Delegate.
 - 3l++) [CLARIFICATION] In the past, puzzles with logos have been permitted for blindfolded events. Such puzzles are no longer permitted.
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -73,7 +73,8 @@ To be more informative, each Guideline is classified using one of the following 
 - 3j++) [CLARIFICATION] On Clock, pins must not be distinguishable from any other pin of the same side.
 - 3j2+) [CLARIFICATION] On Clock, the nine inner clock faces on one side are considered similar pieces.
 - 3k2+) [ADDITION] The WCA Delegate should not apply a listed exception if they believe the competitor tried to use a non-permitted puzzle on purpose.
-- 3k2b+) [EXAMPLE] Suppose the competitor attempts 10 puzzles and solves 8 successfully. If it is found that two solved puzzles and one unsolved puzzle are not permitted, the competitor is considered to have a result with 6 solved puzzles out of 10 (rather than DNF), at the discretion of the WCA Delegate.
+- 3k2b+) [CLARIFICATION] If a non-permitted puzzle is found during the course of a 3x3x3 Multi-Blind attempt, the puzzle must not be exchanged or removed from the attempt and must be counted as unsolved if the entire attempt is not disqualified.
+- 3k2b++) [EXAMPLE] Suppose the competitor attempts 10 puzzles and solves 8 successfully. If it is found that two solved puzzles and one unsolved puzzle are not permitted, the competitor is considered to have a result with 6 solved puzzles out of 10 (rather than DNF), at the discretion of the WCA Delegate.
 - 3l+) [ADDITION] Logos may feature any reasonable design that does not give a conspicuous advantage (e.g. encoding information that could be used to cheat), and leave the colored part clearly recognizable. Unconventional logos are only permitted at the discretion of the WCA Delegate.
 - 3l++) [CLARIFICATION] In the past, puzzles with logos have been permitted for blindfolded events. Such puzzles are no longer permitted.
 


### PR DESCRIPTION
Addresses comments by @pedrosino at https://github.com/thewca/wca-regulations/commit/dfaecca2213de51e7d638b623d3976f95c671fbd#comments

@AlbertoPdRF, could you review?