### PR TITLE
Explicitly allow non-electronic hand warmers and food&drink

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -57,6 +57,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 2i+) [ADDITION] Although the competitor may pick up a stopwatch to view the current time (when they are not blindfolded), they must not start, stop, pause, or otherwise interact with the timekeeping of the stopwatch.
 - 2i++) [ADDITION] The organization team may provide the competitor an unofficial stopwatch for viewing the elapsed time (started together with the main stopwatch), in which case the competitor is not permitted to touch the official stopwatch.
 - 2i1b+) [CLARIFICATION] This includes relevant devices which are switched off or disconnected.
+- 2i1c+) [CLARIFICATION] Electronic hand warmers may be used before or after an attempt only. Non-electronic hand warmers may be used at any time during an attempt.
 - 2j2+) [EXAMPLE] For example, if a competitor is disqualified from an event for failing to show up for the final round, their results from earlier rounds remain valid.
 - 2s+) [REMINDER] Special accommodations must be noted in the Delegate Report.
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -83,6 +83,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 2i1) Competitors may use non-electronic aids that do not give an unfair advantage, at the discretion of the WCA Delegate. This includes:
         - 2i1a) Medical/physical aids worn by the competitor (e.g. glasses, wrist brace). As an exception to [Regulation 2i](regulations:regulation:2i), medical aids may be electronic if the competitor does not have comfortable non-electronic alternatives (e.g. if the competitor has a personal hearing aid or pacemaker).
         - 2i1b) Earplugs and earmuffs (but not electronic headphones and earbuds).
+        - 2i1c) Hand warmers.
+        - 2i1d) Food and drink.
     - 2i2) Competitors may use cameras at the solving station at the discretion of the WCA Delegate, but the following restrictions apply from the start of the attempt until the competitor stops the solve. Penalty for breaking a restriction: disqualification of the attempt (DNF).
         - 2i2a) Each camera monitor must be blank or out of sight of the competitor (see [Regulation A5b](regulations:regulation:A5b)).
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).


### PR DESCRIPTION
Instead of adding this to A5b it makes more sense to add them to 2i1. This parent regulation states already that it is at the discretion of the WCA delegate so it does not need to be included within 2i1c and 2i1d which are being added.

See: https://github.com/thewca/wca-regulations/issues/700