### PR TITLE
Fixes mistakes noticed by Judith Laister

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -96,7 +96,7 @@ This document is meant to clarify some of the implicit conventions adopted in WC
 - "Each" (individual).
 - "Any" (potential, i.e. in case of applicability).
 - "Submit" instead of "hand in" or "turn in".
-- "Scramble program" of "scramble sequences" instead of "scrambling program" or "scrambling sequence".
+- "Scramble program" or "scramble sequences" instead of "scrambling program" or "scrambling sequence".
 
 ### Notable Differences between the Regulations and Common Use
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,7 +180,7 @@ To be more informative, each Guideline is classified using one of the following 
 
 ## <article-B><blindfolded><blindfoldedsolving> Article B: Blindfolded Solving
 
-- B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for 3x3x3 Blindfolded.
+- B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -406,7 +406,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - A6e) After releasing the puzzle, the competitor must not touch or move the puzzle until the judge has inspected the puzzle. Penalty: disqualification of the attempt (DNF). Exception: If no moves have been applied, a time penalty (+2 seconds) may be assigned instead, at the discretion of the judge.
     - A6f) The competitor must not reset the timer until the judge has recorded the result on the score sheet. Penalty: disqualification of the attempt (DNF), at the discretion of the judge.
         - A6f1) If the competitor resets the timer before the result has been completely recorded, the judge must not write down the result from memory or from video or photographic evidence, and must disqualify the attempt instead (DNF).
-    - A6g) The judge determines whether the puzzle is solved. They must not touch the puzzle before they have determined whether to assign a penalty for misalignment.
+    - A6g) The judge determines whether the puzzle is solved. They must not touch the puzzle before they have determined whether to assign a penalty for misalignment. Exception: For Clock, the judge will usually need to pick up the puzzle to verify both faces.
     - A6h) In case of a dispute, moves or alignments must not be applied to the puzzle before the dispute is resolved.
     - A6i) Time penalties for stopping the solve are cumulative.
 - A7) Recording results:


### PR DESCRIPTION
Two main errors we overlooked:
  - #557 actually removed the exception for Clock in A6g, which makes it impossible for the judge to check if a Clock is solved or not.
  - the standardization of event names in #672 and #628 lead to "Blindfolded Solving" being replaced by "3x3x3 Blindfolded" B1+, when it's actually true for any blindfolded event.
