### PR TITLE
Require permission for the competitor to test the timer at the start of a BLD attempt.

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -183,7 +183,8 @@ To be more informative, each Guideline is classified using one of the following 
 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
-- B2d+) [ADDITION] Since the competitor normally starts the solve by starting the timer, the competitor must not "test" or "restart" the timer once the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). Exception: the competitor may test (start and stop/reset) the timer once if they first ask the judge.
+- B2d+) [ADDITION] Since the competitor starts the solve by starting the timer, the competitor must not "test" or "restart" the timer once the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). However, they may ask the judge to start and reset a timer in order to verify that it is working.
+
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -183,7 +183,7 @@ To be more informative, each Guideline is classified using one of the following 
 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
-- B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must ask (and receive an acknowledgement from) the judge before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without asking the judge: disqualification of the attempt (DNF).
+- B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -183,7 +183,7 @@ To be more informative, each Guideline is classified using one of the following 
 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
-
+- B2d+) [ADDITION] Since the competitor normally starts the solve by starting the timer, the competitor must not "test" or "restart" the timer once the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). Exception: the competitor may test (start and stop/reset) the timer once if they first ask the judge.
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -183,7 +183,7 @@ To be more informative, each Guideline is classified using one of the following 
 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
-- B2d+) [ADDITION] Since the competitor starts the solve by starting the timer, the competitor must not "test" or "restart" the timer once the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). However, they may ask the judge to start and reset a timer in order to verify that it is working.
+- B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must ask (and receive an acknowledgement from) the judge before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without asking the judge: disqualification of the attempt (DNF).
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -431,7 +431,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - B1a) There is no inspection period.
     - B1b) The competitor supplies their own blindfold.
 - B2) Starting the attempt:
-    - B2a) The judge resets the timer(s) and asks "READY?" as in [Regulation A3b1](regulations:regulation:A3b1). The competitor must be ready to start the attempt within one minute of being called, else the competitor forfeits the attempt (DNS), at the discretion of the judge.
+    - B2a) The judge resets the timer(s) as in [Regulation A3b](regulations:regulation:A3b) and indicates that they are ready for the competitor to start the attempt (e.g. placing the puzzle cover in front of the competitor, saying "READY", giving a thumbs-up signal). The competitor must start the attempt within one minute, else the competitor forfeits the attempt (DNS), at the discretion of the judge.
     - B2b) The competitor uses their fingers to touch the elevated sensor surfaces of the timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to them. Penalty: time penalty (+2 seconds).
     - B2c) The competitor must have no physical contact with the puzzle before the start of the attempt. Penalty: time penalty (+2 seconds).
     - B2d) The competitor starts the attempt by removing their hands from the timer, thus starting the timer. (This also starts the solve.)


### PR DESCRIPTION
I've thought about this a whole bunch, and I couldn't think of a really good way to specify that the competitor can ask to test the timer (see https://github.com/thewca/wca-regulations/commit/c98b5f7e36451824ab6f07a5f74e83c7672851f3 for a simple attempt). The best compromise I could think of is to allow the *judge* to do this, since this:
- is hard to abuse,
- is unlikely to lead to ambiguity, and
- solves the situation for the only valid use case we can think of (making sure that the timer will actually work for the attempt).

@cubewhiz, what do you think of this revision?
@thewca/wrc-team, could you review?