### PR TITLE
Remove references to 1c3a

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -84,13 +84,13 @@ To be more informative, each Guideline is classified using one of the following 
 ## <article-4><scrambling><scrambling> Article 4: Scrambling
 
 - 4b1+) [REMINDER] The WCA Delegate must never re-generate any scramble sequences to replace other ones for the purpose of filtering. For example, it is not permitted to glance at the scramble sequences for a competition and generate the entire set again in order to generate "fairer" scramble sequences.
-- 4b2+) [CLARIFICATION] In general, all official scramble sequences should be kept secret during the competition and published together after the end of the competition (see [Regulation 1c3a](regulations:regulation:1c3a)). In some cases (e.g. world records), the organization team may wish to release specific scramble sequences sooner after the end of a group.
+- 4b2+) [CLARIFICATION] In general, all official scramble sequences should be kept secret during the competition and published together after the end of the competition. In some cases (e.g. world records), the organization team may wish to release specific scramble sequences sooner after the end of a group.
 - 4b2++) [ADDITION] Competition organizers should ensure that scramblers, scramble sequences, and partially/fully scrambled puzzles are visually isolated from competitors (see [Regulation A2c](regulations:regulation:A2c)). For example, the scramblers may be located behind a wall, or a sufficiently high divider (e.g. a cardboard divider placed around the sides of a table where the scramblers are seated) may be used so that competitors are not able to see puzzles as the scramblers apply scramble sequences.
 - 4b4+) [CLARIFICATION] All attempts that have been started within the time frame follow the standard solving procedure (i.e. they are not stopped when the time frame of the relevant scramble sequence expires).
 - 4d+) [CLARIFICATION] Some puzzles use standard color schemes, except that white is replaced with black. In this case, black is the darkest color and must not be treated as white.
 - 4d++) [ADDITION] It is permitted for the puzzle to change its orientation when it is moved from the scrambler to the solving station, as long as no one is attempting to influence the randomness of the orientation (see [Regulation A2e1](regulations:regulation:A2e1)).
 - 4f+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.
-- 4f++) [REMINDER] If the WCA Delegate generates any additional scramble sequences during the competition, the scramble sequences must be saved (see [Regulation 1c3a](regulations:regulation:1c3a)).
+- 4f++) [REMINDER] If the WCA Delegate generates any additional scramble sequences during the competition, the scramble sequences must be saved.
 
 
 ## <article-5><puzzle-defects><puzzledefects> Article 5: Puzzle Defects


### PR DESCRIPTION
`1c3a` was removed in https://github.com/thewca/wca-regulations/pull/673 , but the references to it remain in the Guidelines. We can remove them, or replace them to an alternative?