### PR TITLE
Clarify Puzzle on Surface Solving

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -189,7 +189,6 @@ To be more informative, each Guideline is classified using one of the following 
 
 - C1b+) [CLARIFICATION] The competitor may use both hands during inspection.
 - C1b++) [CLARIFICATION] The competitor is not required to use the same solving hand for different attempts of the same round.
-- C1b+++) [REMINDER] Use of the surface is permitted while solving or repairing the puzzle.
 
 
 ## <article-D><feet><solvingwithfeet> Article D: Feet Solving

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -391,7 +391,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - A4e) Time penalties for starting the solve are cumulative.
 - A5) During the solve:
     - A5a) While inspecting or solving the puzzle, the competitor must not communicate with anyone other than the judge or the WCA Delegate. Penalty: disqualification of the attempt (DNF).
-    - A5b) While inspecting or solving the puzzle, the competitor must not receive assistance from anyone or any object other than the surface (also see [Regulation 2i](regulations:regulation:2i)). Penalty: disqualification of the attempt (DNF).
+    - A5b) While inspecting or solving the puzzle, the competitor must not receive assistance from anyone or any object other than the surface (also see [Regulation 2i](regulations:regulation:2i))(e.g. holding the puzzle against the surface to help operate the puzzle). Penalty: disqualification of the attempt (DNF).
 - A6) Stopping the solve:
     - A6a) The competitor releases the puzzle before stopping the solve, and stops the solve by stopping the timer. If a stopwatch is in use, the judge stops the stopwatch as soon as the competitor does this.
         - A6a1) When using a stopwatch as the only timer, the competitor stops the solve by releasing the puzzle and notifying the judge that they have stopped the solve. The judge stops the stopwatch as soon as the competitor does this.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -461,6 +461,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - C1b) During the solve, the competitor must use only one hand to operate the puzzle. Penalty: disqualification of the attempt (DNF).
         - C1b2) If a puzzle defect occurs, and the competitor chooses to repair it, they must repair it using only the solving hand. Penalty: disqualification of the attempt (DNF).
         - C1b3) If other body parts of the competitor come in contact with the puzzle or parts of the puzzle without the competitor's intention and without applying moves, this is not considered operating the puzzle, at the discretion of the judge.
+        - C1b4) During the solve, the competitors may choose to put the puzzle on the surface.
     - C1c) During the solve, once a competitor operates the puzzle with one hand, they must not operate the puzzle with the other hand. Penalty: disqualification of the attempt (DNF).
 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -461,7 +461,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - C1b) During the solve, the competitor must use only one hand to operate the puzzle. Penalty: disqualification of the attempt (DNF).
         - C1b2) If a puzzle defect occurs, and the competitor chooses to repair it, they must repair it using only the solving hand. Penalty: disqualification of the attempt (DNF).
         - C1b3) If other body parts of the competitor come in contact with the puzzle or parts of the puzzle without the competitor's intention and without applying moves, this is not considered operating the puzzle, at the discretion of the judge.
-        - C1b4) During the solve, the competitors may choose to put the puzzle on the surface.
+        - C1b4) During the solve, the competitor may hold the puzzle against the surface to help operate the puzzle.
     - C1c) During the solve, once a competitor operates the puzzle with one hand, they must not operate the puzzle with the other hand. Penalty: disqualification of the attempt (DNF).
 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -391,7 +391,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - A4e) Time penalties for starting the solve are cumulative.
 - A5) During the solve:
     - A5a) While inspecting or solving the puzzle, the competitor must not communicate with anyone other than the judge or the WCA Delegate. Penalty: disqualification of the attempt (DNF).
-    - A5b) While inspecting or solving the puzzle, the competitor must not receive assistance from anyone or any object other than the surface (also see [Regulation 2i](regulations:regulation:2i))(e.g. holding the puzzle against the surface to help operate the puzzle). Penalty: disqualification of the attempt (DNF).
+    - A5b) While inspecting or solving the puzzle, the competitor must not receive assistance from anyone or any object other than the surface (also see [Regulation 2i](regulations:regulation:2i)). Penalty: disqualification of the attempt (DNF).
+    - A5c) The competitor may hold the puzzle against the surface to help operate the puzzle.(see [Regulation 7f1d](regulations:regulation:7f1d))
 - A6) Stopping the solve:
     - A6a) The competitor releases the puzzle before stopping the solve, and stops the solve by stopping the timer. If a stopwatch is in use, the judge stops the stopwatch as soon as the competitor does this.
         - A6a1) When using a stopwatch as the only timer, the competitor stops the solve by releasing the puzzle and notifying the judge that they have stopped the solve. The judge stops the stopwatch as soon as the competitor does this.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -392,7 +392,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - A5) During the solve:
     - A5a) While inspecting or solving the puzzle, the competitor must not communicate with anyone other than the judge or the WCA Delegate. Penalty: disqualification of the attempt (DNF).
     - A5b) While inspecting or solving the puzzle, the competitor must not receive assistance from anyone or any object other than the surface (also see [Regulation 2i](regulations:regulation:2i)). Penalty: disqualification of the attempt (DNF).
-    - A5c) The competitor may hold the puzzle against the surface to help operate the puzzle.(see [Regulation 7f1d](regulations:regulation:7f1d))
+    - A5c) The competitor may hold the puzzle against the surface to help operate the puzzle (see [Regulation 7f1d](regulations:regulation:7f1d)).
 - A6) Stopping the solve:
     - A6a) The competitor releases the puzzle before stopping the solve, and stops the solve by stopping the timer. If a stopwatch is in use, the judge stops the stopwatch as soon as the competitor does this.
         - A6a1) When using a stopwatch as the only timer, the competitor stops the solve by releasing the puzzle and notifying the judge that they have stopped the solve. The judge stops the stopwatch as soon as the competitor does this.
@@ -462,7 +462,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - C1b) During the solve, the competitor must use only one hand to operate the puzzle. Penalty: disqualification of the attempt (DNF).
         - C1b2) If a puzzle defect occurs, and the competitor chooses to repair it, they must repair it using only the solving hand. Penalty: disqualification of the attempt (DNF).
         - C1b3) If other body parts of the competitor come in contact with the puzzle or parts of the puzzle without the competitor's intention and without applying moves, this is not considered operating the puzzle, at the discretion of the judge.
-        - C1b4) During the solve, the competitor may hold the puzzle against the surface to help operate the puzzle.
+        - C1b4) During the solve, the competitor may hold the puzzle against the surface to help operate the puzzle (see [Regulation 7f1d](regulations:regulation:7f1d)).
     - C1c) During the solve, once a competitor operates the puzzle with one hand, they must not operate the puzzle with the other hand. Penalty: disqualification of the attempt (DNF).
 
 


### PR DESCRIPTION
Clarifying the use of surface during one handed solve.
Issue[#718](<https://github.com/thewca/wca-regulations/issues/718>)