### PR TITLE
Clarify camera display

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -56,7 +56,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 2i++) [ADDITION] The organization team may provide the competitor an unofficial stopwatch for viewing the elapsed time (started together with the main stopwatch), in which case the competitor is not permitted to touch the official stopwatch.
 - 2i1b+) [CLARIFICATION] This includes relevant devices which are switched off or disconnected.
 - 2i1c+) [CLARIFICATION] Electronic hand warmers may be used before or after an attempt only. Non-electronic hand warmers may be used at any time during an attempt.
-- 2i2a+) [ADDITION] The monitor of a camera can be visibale to the competitor as long as it does not show the live feed of the camera.
+- 2i2a+) [ADDITION] The monitor of a camera can be visible to the competitor as long as it does not show the live feed of the camera.
 - 2j2+) [EXAMPLE] For example, if a competitor is disqualified from an event for failing to show up for the final round, their results from earlier rounds remain valid.
 - 2s+) [REMINDER] Special accommodations must be noted in the Delegate Report.
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -56,6 +56,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 2i++) [ADDITION] The organization team may provide the competitor an unofficial stopwatch for viewing the elapsed time (started together with the main stopwatch), in which case the competitor is not permitted to touch the official stopwatch.
 - 2i1b+) [CLARIFICATION] This includes relevant devices which are switched off or disconnected.
 - 2i1c+) [CLARIFICATION] Electronic hand warmers may be used before or after an attempt only. Non-electronic hand warmers may be used at any time during an attempt.
+- 2i2a+) [ADDITION] The monitor of a camera can be visibale to the competitor as long as it does not show the live feed of the camera.
 - 2j2+) [EXAMPLE] For example, if a competitor is disqualified from an event for failing to show up for the final round, their results from earlier rounds remain valid.
 - 2s+) [REMINDER] Special accommodations must be noted in the Delegate Report.
 


### PR DESCRIPTION
Addressing issue #721, so display/monitor/screen without live feed of the filming can be front facing.