### PR TITLE
Add guideline B4c+ (BLD sight blocker timing)

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -187,7 +187,6 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
-- B4c+) [ADDITION] The judge should wait for the competitor to apply the first move to the puzzle before putting up the sight blocker to avoid interrupting the attempt (see [Regulation B4e](regulations:regulation:B4e)).
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -187,6 +187,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
+- B4c+) [ADDITION] The judge should wait for the competitor to apply the first move to the puzzle before putting up the sight blocker to avoid interrupting the attempt (see [Regulation B4e](regulations:regulation:B4e)).
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -446,7 +446,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - B4) Blindfolded phase:
     - B4a) The competitor dons the blindfold to start the blindfolded phase.
     - B4b) The competitor must not apply moves to the puzzle before they have fully donned the blindfold. Penalty: disqualification of the attempt (DNF).
-    - B4c) After the competitor has applied the first move to the puzzle, the judge must ensure that there is a sight blocker (e.g. a sheet of paper or cardboard) between the competitor's face and the puzzle.
+    - B4c) As soon as the competitor applies the first move to the puzzle, the judge must ensure that there is a sight blocker (e.g. a sheet of paper or cardboard) between the competitor's face and the puzzle.
         - B4c1) In all cases, the competitor must wear the blindfold such that their view of the puzzle would still clearly be blocked if the sight blocker were not in the way.
         - B4c3) If the judge and competitor agree beforehand, the competitor may choose to place the puzzle behind a suitable object (e.g. a music stand, the surface of the table) by themselves during the blindfolded phase.
     - B4d) The competitor must not look at the puzzle at any point during the blindfolded phase. Penalty: disqualification of the attempt (DNF).

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -446,9 +446,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - B4) Blindfolded phase:
     - B4a) The competitor dons the blindfold to start the blindfolded phase.
     - B4b) The competitor must not apply moves to the puzzle before they have fully donned the blindfold. Penalty: disqualification of the attempt (DNF).
-    - B4c) The judge must ensure that there is a sight blocker between the competitor's face and the puzzle while the competitor is solving.
+    - B4c) After the competitor has applied the first move to the puzzle, the judge must ensure that there is a sight blocker (e.g. a sheet of paper or cardboard) between the competitor's face and the puzzle.
         - B4c1) In all cases, the competitor must wear the blindfold such that their view of the puzzle would still clearly be blocked if the sight blocker were not in the way.
-        - B4c2) By default, the judge should place the object (e.g. a sheet of paper or cardboard) between the competitor and the puzzle while the competitor is wearing the blindfold.
         - B4c3) If the judge and competitor agree beforehand, the competitor may choose to place the puzzle behind a suitable object (e.g. a music stand, the surface of the table) by themselves during the blindfolded phase.
     - B4d) The competitor must not look at the puzzle at any point during the blindfolded phase. Penalty: disqualification of the attempt (DNF).
     - B4e) Until the competitor applies the first move to the puzzle, they may remove the blindfold to return to the memorization phase.


### PR DESCRIPTION
The judge should put up the sight blocker after the competitors have applied the first move, because competitors can remove the blindfold if they have not applied any moves.

Thanks @denthebro for pointing out this. #948 