### PR TITLE
Adaptation of 9p1 to reflect WRC decision - Fixes #220

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -258,6 +258,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9m3) Rounds with 7 or fewer competitors must not have subsequent rounds.
 - 9o) Cutoff rounds count as one round when counting the number of rounds per event.
 - 9p) If an event has multiple rounds, then:
+    - 9p1) At least 25% of competitors that had results when the round ended must be eliminated between consecutive rounds of the same event.
     - 9p2) The competitors who advance to the next round must be determined by ranking (best x competitors) or by result (all competitors with a better result than x) in the preceding round.
         - 9p2a) For each round, advancement conditions must be announced before the round starts, and should not be changed after it has begun. Changes must be made at the discretion of the WCA Delegate, who must carefully consider the fairness of the change.
     - 9p3) If a qualifying competitor withdraws from a round, they may be replaced by the best-ranked non-qualifying competitor from the preceding round.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -253,12 +253,11 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the Board.
 - 9l) Each round must be completed before any following round of the same event can start.
 - 9m) Events must have at most four rounds.
-    - 9m1) Rounds with 99 or fewer competitors must have at most two subsequent rounds.
-    - 9m2) Rounds with 15 or fewer competitors must have at most one subsequent round.
+    - 9m1) Rounds with 99 or fewer competitors that had results when the round ended must have at most two subsequent rounds.
+    - 9m2) Rounds with 15 or fewer competitors that had results when the round ended must have at most one subsequent round.
     - 9m3) Rounds with 7 or fewer competitors must not have subsequent rounds.
 - 9o) Cutoff rounds count as one round when counting the number of rounds per event.
 - 9p) If an event has multiple rounds, then:
-    - 9p1) At least 25% of competitors with recorded results at the time the round ended must be eliminated between consecutive rounds of the same event.
     - 9p2) The competitors who advance to the next round must be determined by ranking (best x competitors) or by result (all competitors with a better result than x) in the preceding round.
         - 9p2a) For each round, advancement conditions must be announced before the round starts, and should not be changed after it has begun. Changes must be made at the discretion of the WCA Delegate, who must carefully consider the fairness of the change.
     - 9p3) If a qualifying competitor withdraws from a round, they may be replaced by the best-ranked non-qualifying competitor from the preceding round.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -258,7 +258,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9m3) Rounds with 7 or fewer competitors must not have subsequent rounds.
 - 9o) Cutoff rounds count as one round when counting the number of rounds per event.
 - 9p) If an event has multiple rounds, then:
-    - 9p1) At least 25% of competitors must be eliminated between consecutive rounds of the same event.
+    - 9p1) At least 25% of competitors with recorded results at the time the round ended must be eliminated between consecutive rounds of the same event.
     - 9p2) The competitors who advance to the next round must be determined by ranking (best x competitors) or by result (all competitors with a better result than x) in the preceding round.
         - 9p2a) For each round, advancement conditions must be announced before the round starts, and should not be changed after it has begun. Changes must be made at the discretion of the WCA Delegate, who must carefully consider the fairness of the change.
     - 9p3) If a qualifying competitor withdraws from a round, they may be replaced by the best-ranked non-qualifying competitor from the preceding round.


### PR DESCRIPTION
This PR reflects the understanding the WRC adopted on the decision made on [Incident 56](https://www.worldcubeassociation.org/incidents/56) and fixes #220 

With the proposed wording for Regulation 9p1, round results in which a competitor should not have competed in can be removed without affecting the results of other competitors.

This is because the obligatory elimination of 25% of the competitors between rounds will be applied on _competitors with recorded results at the time the round ended_. Therefore, if a competitor found guilty of cheating has their result removed at a later date, the number of competitors able to advance to the following round won't decrease, as the competitor found guilty of cheating did have recorded results at the time the round ended.

EDTI: Adding further explanation of the proposal.

The proposed wording for 9p1 is meant to be a blanket solution to all possible cases of posterior changes to results that result in fewer competitors being able to advance to the next round.

Currently, 9p1 states that "at least 25% of competitors must be eliminated between consecutive rounds of the same event."

Following this wording, when there's a scoretaking mistake or a decision on a disciplinary incident that results in fewer competitors being able to advance to a consecutive round, we always face a dilemma: do we remove the results of innocent competitors (preventing a violation of 9p1) or do we allow innocent competitors to keep their results, even if the obligatory elimination of at least 25% of competitors between rounds would've prevented them from competing in the following round (being guided by fair sportsmanship, as dictates 11d)?

With the proposed wording for Regulation 9p1, we do not have to make this choice!

Here's what my proposal looks like:

"9p1) At least 25% of competitors of competitors _with recorded results at the time the round ended_ must be eliminated between consecutive rounds of the same event."

Let's say a decision on a disciplinary incident forces us to remove the results of a competitor on the second round of an event, with 16 competitors on it.

Following the logic of the current wording of 9p1, this reduces the number of competitors that could advance to the third round. The competitor that placed 12th, not related to the disciplinary incident, would have to have his results removed from the third round of the event, because 9p1 dictates that at most 11 competitors can advance in a round where 15 competitors had competed in.

However, with the proposed wording for 9p1, the innocent competitor would be able to keep his results! This is because the competitor involved in the disciplinary incident, who had his results removed, did have recorded results at the time the round ended. His results on the second round were only removed afterwards.

This makes it so the competitor involved in the disciplinary incident counts towards the 25% obligatory elimination, even if his results were removed.

The proposed wording of 9p1 serves as a blanket solution to any similar situation, and gives competitors not related to these incidents assurance that their results won't be affected by a change in the results of another competitor.
