### PR TITLE
Improving the wording of Regulation 11g

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -297,7 +297,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 11e2) If a competitor is granted an extra attempt, the extra attempt should be done right after the attempt that caused it, and must replace the original regularly numbered attempt.
     - 11e3) If it is unclear whether an incident should result in an extra attempt, the competitor may be granted a provisional extra attempt that will be used only if it is later found that an extra attempt was appropriate (e.g. by a decision of the WRC).
 - 11f) Decisions about an incident may be supported with video or photographic analysis, at the discretion of the WCA Delegate.
-- 11g) The WCA Delegate must ensure that copies of the Regulations and Guidelines are available (e.g. printed, digital, or accessible via internet) to consult for any incidents.
+- 11g) The WCA Delegate must ensure that copies of the Regulations and Guidelines are available (e.g. printed, digital, or accessible via internet) to officials and competitors for consultation on any incidents.
 
 
 ## <article-12><notation><notation> Article 12: Notation


### PR DESCRIPTION
As pointed out in issue #874 , Regulation 11g currently doesn't make it clear that Delegates have to ensure copies of the Regulations and Guidelines are available to all competitors and officials, and not only to himself.

Rather than adding a Guideline to clear this up, we can fix this by simply adding the Regulations must be available to "officials and compeitors" with the appropriate changes in propositions and wording to make this work.

This is also in harmony with the discussions in [this](https://forum.worldcubeassociation.org/t/removing-11g/1303) topic of the WCA Forum and this issue in the `thewca/wca-documents` repository.