### PR TITLE
Clarify how to handle results of disqualified attempts

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -88,7 +88,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
-        - 2j1a) If the competitor had already started at least one attempt in a round before being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor had started no attempts, no results should be recorded.
+        - 2j1a) If the competitor had already started at least one attempt in a round before being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor had started no attempts, no results are recorded.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -88,7 +88,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
-        - 2j1a) The results of all remaining attempts in the event are recorded as DNF.
+        - 2j1a) If the competitor has already finished one or more attempts in a round after being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor has finished no attempts, no results should be recorded.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -88,7 +88,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
-        - 2j1a) If the competitor had already started at least one attempt in a round before being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor had started no attempts, no results are recorded.
+        - 2j1a) If the competitor has already started at least one attempt in a round before being disqualified from it, the results of all remaining attempts in the event are recorded as DNF. If the competitor has started no attempts (i.e. has no results or only has DNS results), no results are recorded.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -88,7 +88,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
-        - 2j1a) If the competitor has already finished one or more attempts in a round after being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor has finished no attempts, no results should be recorded.
+        - 2j1a) If the competitor had already started at least one attempt in a round before being disqualified, the results of all remaining attempts in the event are recorded as DNF. If the competitor had started no attempts, no results should be recorded.
     - 2j2) If a competitor is disqualified during the course of an event, their earlier results remain valid. Exception: cheating or defrauding (see [Regulation 2k2a](regulations:regulation:2k2a)).
 - 2k) At the discretion of the WCA Delegate, a competitor may be disqualified from some events (a single event, multiple events, or all events) if the competitor:
     - 2k1) Fails to check in or register in time for the competition.


### PR DESCRIPTION
This PR change clarifies how should the results of disqualified attempts be handled.

It comes as a result of [incident log #58](https://www.worldcubeassociation.org/incidents/58), in which a competitor was disqualified at the start of a round before having finished any attempts. In alignment with Regulation 2j1a, the Delegate recorded all of his attempts as DNFs.

However, this artificially increases the number of competitors in a round (see Regulation 9m1-9m3) and misrepresents what happened in practice.

The proposed wording for 2j1a makes it clear that the rest of the remaining attempts should only be recorded as DNFs if the competitor has finished one or more attempts. Otherwise, if the competitor has finished no attempts, as is the case in the aforementioned incident log, no results should be recorded.