### PR TITLE
Clarify who can approve not allowing competitiors to participate in all events of a competition

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -250,7 +250,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9i2) All the results of a round are considered to take place on the last calendar date of the round. If a regional record is broken multiple times on the same calendar date, only the best result is recognized as breaking that regional record.
     - 9i3) If the WCA Regulations for an event are changed, existing regional records stand until they are broken under the new WCA Regulations.
 - 9j) Each event must be held at most once per competition.
-- 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the Board.
+- 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the WCA.
 - 9l) Each round must be completed before any following round of the same event can start.
 - 9m) Events must have at most four rounds.
     - 9m1) Rounds with 99 or fewer competitors must have at most two subsequent rounds.


### PR DESCRIPTION
This PR clarifies who can approve competitors not participating in all events of a competition.

As highlighted by @Epride [here](https://forum.worldcubeassociation.org/t/inaccuracy-of-regulation-9k/8926),  Regulation 9k currently inaccurately states that the WCA Board is the one responsible for approving that competitors aren't able to participate in all events of a competition.

However, in almost all cases, this approval is not carried out by the Board, but by the WCAT.

This PR, therefore, makes it clear that the Board specifically doesn't need to give the mentioned approval.

We chose not to change the wording in the Regulation mentioning specifically the WCAT so that the Regulations doesn't need to be updated if the Team changes its name or if anoother entity in the WCA becomes responsible for the approval.