### PR TITLE
Eliminating repeated WCRP content in Guidelines

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -43,8 +43,6 @@ To be more informative, each Guideline is classified using one of the following 
 ## <article-2><competitors><competitors> Article 2: Competitors
 
 - 2c+) [ADDITION] First-time competitors should register using their legal name. They may register using a reasonable nickname, at the discretion of the WCA Delegate.
-- 2c1+) [ADDITION] The requirements for a completed registration must be clearly stated on the competition website.
-- 2c1++) [EXAMPLE] For example, the organization team may require a confirmation e-mail to be answered before a particular date, pre-payment of the registration fee, or paying due registration fees of past competitions. The organization team should carefully consider the fairness of the requirements.
 - 2c2+) [CLARIFICATION] A WCA profile is the collection of data related to a competitor, and includes their personal information (name, nationality, gender, and date of birth) as well as all their results in official WCA competitions.
 - 2d+) [ADDITION] Date of birth and contact information should be especially secured.
 - 2d++) [RECOMMENDATION] If a third party (e.g. journalist) asks the organization team to be put in contact with any competitor(s), the competitor(s) should first be asked for consent.


### PR DESCRIPTION
Eliminating already stated content in WCRP.

[Discussion in the WCA forum](https://forum.worldcubeassociation.org/t/2c1-and-2c1-are-already-in-the-wcrp/1288)