### PR TITLE
And/or consistency with 7f1a

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -197,7 +197,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 7e) The competition area must be smoke-free.
 - 7f) Solving station:
     - 7f1) Definitions:
-        - 7f1a) Stackmat: The Speed Stacks Stackmat timer and a full-size compatible mat. Generation 2, Generation 3 Pro Timer, or/and Generation 4 Pro Timer must be used for time measurement.
+        - 7f1a) Stackmat: The Speed Stacks Stackmat timer and a full-size compatible mat. Generation 2, Generation 3 Pro Timer, and/or Generation 4 Pro Timer must be used for time measurement.
         - 7f1b) Mat: The mat of the Stackmat.
         - 7f1c) Timer: The timer of the Stackmat, or a stopwatch (for longer attempts).
         - 7f1d) Surface: The flat surface on which the Stackmat has been placed. The mat is considered a part of the surface. The timer is not considered a part of the surface.


### PR DESCRIPTION
Forum link: [https://forum.worldcubeassociation.org/t/and-or-consistency-with-7f1a/12834](https://forum.worldcubeassociation.org/t/and-or-consistency-with-7f1a/12834)