### PR TITLE
Regulation H1e wording improvement

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -515,7 +515,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - H1b) If a competitor is attempting fewer than 6 puzzles, they are allotted a time limit of 10 minutes times the number of puzzles in the attempt, else the time limit is 60 minutes.
         - H1b1) The competitor may signal the end of the solve at any time. If and when the time limit is reached, the judge stops the attempt and the attempt is then scored; the time limit for the attempt counts as the original recorded time.
     - H1d) Time penalties for the puzzles of the attempt are cumulative.
-    - H1e) If a competitor accidentally applies any moves to one or more puzzles during the memorization phase, those puzzles may be considered unsolved at the end of the attempt (instead of immediately disqualifying the entire attempt), at the discretion of the WCA Delegate.
+    - H1e) The competitor must not apply any moves to one or more puzzles during the memorization phase. Penalty: disqualification of the attempt (DNF). Exception: those puzzles may be considered unsolved at the end of the attempt, at the discretion of the WCA Delegate.
 
 
 ## <article-Y><temporary-regulations><temporaryregulations> Article Y: Temporary Regulations

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -515,7 +515,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - H1b) If a competitor is attempting fewer than 6 puzzles, they are allotted a time limit of 10 minutes times the number of puzzles in the attempt, else the time limit is 60 minutes.
         - H1b1) The competitor may signal the end of the solve at any time. If and when the time limit is reached, the judge stops the attempt and the attempt is then scored; the time limit for the attempt counts as the original recorded time.
     - H1d) Time penalties for the puzzles of the attempt are cumulative.
-    - H1e) The competitor must not apply any moves to one or more puzzles during the memorization phase. Penalty: disqualification of the attempt (DNF). Exception: those puzzles may be considered unsolved at the end of the attempt, at the discretion of the WCA Delegate.
+    - H1e) The competitor must not apply any moves to one or more puzzles during the memorization phase. Penalty: disqualification of the attempt (DNF). Exception: these individual puzzles may be considered unsolved at the end of the attempt instead of disqualifying the entire attempt, at the discretion of the WCA Delegate.
 
 
 ## <article-Y><temporary-regulations><temporaryregulations> Article Y: Temporary Regulations


### PR DESCRIPTION
From @Jambrose777 suggestion.

I think it would also make sense to maintain the parentheses' clarification "(instead of immediately disqualifying the entire attempt)".