### PR TITLE
Improve the wording of Regulation 9k

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -250,7 +250,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 9i2) All the results of a round are considered to take place on the last calendar date of the round. If a regional record is broken multiple times on the same calendar date, only the best result is recognized as breaking that regional record.
     - 9i3) If the WCA Regulations for an event are changed, existing regional records stand until they are broken under the new WCA Regulations.
 - 9j) Each event must be held at most once per competition.
-- 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the WCA.
+- 9k) All competitors may participate in all events of a competition, except in cases specifically approved by the WCA Competition Announcement Team.
 - 9l) Each round must be completed before any following round of the same event can start.
 - 9m) Events must have at most four rounds.
     - 9m1) Rounds with 99 or fewer competitors must have at most two subsequent rounds.


### PR DESCRIPTION
This commit improves the wording of Regulation 9k by making it clearer who can approve competitiors not being allowed to participate in all rounds of an event.

This comes as a result of @Jambrose777 's suggestion, and builds on what was proposed on PR #998.