### PR TITLE
Strongly recommend competitors to turn off notifications and calls

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -87,7 +87,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2a) Each camera monitor must be blank or out of sight of the competitor (see [Regulation A5b](regulations:regulation:A5b)).
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
     - 2i3) The competitor may have a cell phone in their pocket, as long as it is clear that they are not otherwise interacting with it.
-    - 2i4) Competitors should turn off all cell phone notifications while competing to avoid disturbing themselves or others.
+    - 2i4) Competitors should turn off all cell phone notifications while competing to avoid disturbing the competition.
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
         - 2j1a) If the competitor has already started at least one attempt in a round before being disqualified from it, the results of all remaining attempts in the event are recorded as DNF. If the competitor has started no attempts (i.e. has no results or only has DNS results), no results are recorded.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -87,6 +87,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 2i2a) Each camera monitor must be blank or out of sight of the competitor (see [Regulation A5b](regulations:regulation:A5b)).
         - 2i2b) The competitor must not interact with (e.g. operate, hold, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
     - 2i3) The competitor may have a cell phone in their pocket, as long as it is clear that they are not otherwise interacting with it.
+    - 2i4) Competitors should turn off all cell phone notifications while competing to avoid disturbing themselves or others.
 - 2j) The WCA Delegate may disqualify a competitor from a specific event.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.
         - 2j1a) If the competitor has already started at least one attempt in a round before being disqualified from it, the results of all remaining attempts in the event are recorded as DNF. If the competitor has started no attempts (i.e. has no results or only has DNS results), no results are recorded.


### PR DESCRIPTION
In alignment with what was discussed in the WRC meeting and as a partial consequence of [this discussion](https://forum.worldcubeassociation.org/t/proposal-a-competitor-must-not-interact-with-a-mobile-phone/3215), this PR adds a Regulation stating that competitors should turn off all cell phone notifications while competing.