### PR TITLE
Clarification on late competitors to rounds with cumulative time limits

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -58,6 +58,7 @@ To be more informative, each Guideline is classified using one of the following 
 - 2j2+) [EXAMPLE] For example, if a competitor is disqualified from an event for failing to show up for the final round, their results from earlier rounds remain valid.
 - 2k6+) [CLARIFICATION] WCA Delegates should only use their discretion to prevent competitors from being a severe detriment to the competition (e.g. wasting time and/or competition resources). Competitors should not be disqualified for a "poor" result when they are competing to the best of their abilities.
 - 2s+) [REMINDER] Special accommodations must be noted in the Delegate Report.
+- 2u1+) [ADDITION] The competitor may compete at the discretion of the WCA Delegate. The WCA Delegate must carefully consider the fairness of allowing it.
 
 
 ## <article-3><puzzles><puzzles> Article 3: Puzzles

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -109,7 +109,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 2t) Each competitor must be familiar with and understand the WCA Regulations before the competition.
 - 2u) Competitors must be present and ready to compete when they are called to compete for an attempt. Penalty: disqualification from the event.
     - 2u1) Exception: A competitor who is not present in time for an individually scheduled attempt (e.g. a 3x3x3 Fewest Moves attempt, a 3x3x3 Multi-Blind attempt) may be considered to have declined that attempt (DNS), at the discretion of the WCA Delegate.
-    2u2) Exception: A competitor who arrives late for a round where a cumulative time limit is applied may compete with a reduced cumulative time limit, at the discretion of the WCA Delegate.
+    - 2u2) Exception: A competitor who arrives late for a round where a cumulative time limit is applied may compete with a reduced cumulative time limit, at the discretion of the WCA Delegate.
 
 
 ## <article-3><puzzles><puzzles> Article 3: Puzzles

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -109,6 +109,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 2t) Each competitor must be familiar with and understand the WCA Regulations before the competition.
 - 2u) Competitors must be present and ready to compete when they are called to compete for an attempt. Penalty: disqualification from the event.
     - 2u1) Exception: A competitor who is not present in time for an individually scheduled attempt (e.g. a 3x3x3 Fewest Moves attempt, a 3x3x3 Multi-Blind attempt) may be considered to have declined that attempt (DNS), at the discretion of the WCA Delegate.
+    2u2) Exception: A competitor who arrives late for a round where a cumulative time limit is applied may compete with a reduced cumulative time limit, at the discretion of the WCA Delegate.
 
 
 ## <article-3><puzzles><puzzles> Article 3: Puzzles

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -109,7 +109,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 2t) Each competitor must be familiar with and understand the WCA Regulations before the competition.
 - 2u) Competitors must be present and ready to compete when they are called to compete for an attempt. Penalty: disqualification from the event.
     - 2u1) Exception: A competitor who is not present in time for an individually scheduled attempt (e.g. a 3x3x3 Fewest Moves attempt, a 3x3x3 Multi-Blind attempt) may be considered to have declined that attempt (DNS), at the discretion of the WCA Delegate.
-    - 2u2) Exception: A competitor who arrives late for a round where a cumulative time limit is applied may compete with a reduced cumulative time limit, at the discretion of the WCA Delegate.
+    - 2u2) Exception: For rounds with a cumulative time limit, a competitor who arrives late may compete with a reduced cumulative time limit, at the discretion of the WCA Delegate.
 
 
 ## <article-3><puzzles><puzzles> Article 3: Puzzles


### PR DESCRIPTION
See the [WCA Forum discussion](https://forum.worldcubeassociation.org/t/clarify-rules-regarding-late-competitors-to-rounds-with-cumulative-time-limits/1277/2).