### PR TITLE
Add clarification on judges forgetting to put a sight blocker

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,6 +180,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
+- B4c+) [ADDITION] An attempt should not be disqualified solely due to the judge not putting a sight blocker. However, the WCA Delegate may replace the attempt with an extra attempt if they have a reason to suspect that the competitor gained an unfair advantage.
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,7 +180,8 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
-- B4c+) [ADDITION] An attempt should not be disqualified or replaced with an extra attempt solely due to the judge not putting a sight blocker. However, the WCA Delegate may replace the attempt with an extra attempt if they have a reason to suspect that the competitor gained an unfair advantage. Exception: if the competitor had to put a sight blocker themselves (see [Regulation B4c3](regulations:regulation:B4c3)), the attempt should be disqualified, at the discretion of the WCA Delegate.
+- B4c+) [ADDITION] if the judge forgot to put a sight blocker (or did not put it immediately), the WCA Delegate should always grant an extra attempt.
+- B4c++) [ADDITION] If the WCA Delegate does not suspect any infraction of the regulations by the competitor, the original attempt may stand.
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -181,7 +181,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
 - B4c+) [ADDITION] If the judge forgot to put a sight blocker, or places it in a way that the competitor's view of the puzzle is not fully blocked, the WCA Delegate should grant an extra attempt.
-- B4c++) [ADDITION] If the WCA Delegate does not suspect any infraction of the regulations by the competitor, the original attempt may stand.
+- B4c++) [ADDITION] If the WCA Delegate does not suspect that the competitor intentionally violated any WCA Regulations, the original attempt may stand.
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,7 +180,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
-- B4c+) [ADDITION] An attempt should not be disqualified solely due to the judge not putting a sight blocker. However, the WCA Delegate may replace the attempt with an extra attempt if they have a reason to suspect that the competitor gained an unfair advantage.
+- B4c+) [ADDITION] An attempt should not be disqualified or replaced with an extra attempt solely due to the judge not putting a sight blocker. However, the WCA Delegate may replace the attempt with an extra attempt if they have a reason to suspect that the competitor gained an unfair advantage. Exception: if the competitor had to put a sight blocker themselves (see [Regulation B4c3](regulations:regulation:B4c3)), the attempt should be disqualified, at the discretion of the WCA Delegate.
 
 
 ## <article-C><one-handed><onehandedsolving> Article C: One-Handed Solving

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,7 +180,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
-- B4c+) [ADDITION] If the judge forgot to put a sight blocker (or did not put it immediately), the WCA Delegate should always grant an extra attempt.
+- B4c+) [ADDITION] If the judge forgot to put a sight blocker, or places it in a way that the competitor's view of the puzzle is not fully blocked, the WCA Delegate should grant an extra attempt.
 - B4c++) [ADDITION] If the WCA Delegate does not suspect any infraction of the regulations by the competitor, the original attempt may stand.
 
 

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -180,7 +180,7 @@ To be more informative, each Guideline is classified using one of the following 
 - B1+) [REMINDER] The competitor must use a puzzle without textures, markings, or other features that distinguish similar pieces (see [Regulation 3k](regulations:regulation:3k)). This should be given special attention for Blindfolded Solving.
 - B1b+) [RECOMMENDATION] Blindfolds should be checked by the WCA Delegate before use in the competition.
 - B2d+) [ADDITION] By default, the competitor starts the solve the first time that they start the timer after the judge has indicated that they are ready (see [Regulation B2a](regulations:regulation:B2a)). If they want to check that the timer is in working order, they must (ask and) receive confirmation from the judge each time before starting/resetting the timer during this phase. Penalty for starting and resetting a timer without confirmation from the judge: disqualification of the attempt (DNF).
-- B4c+) [ADDITION] if the judge forgot to put a sight blocker (or did not put it immediately), the WCA Delegate should always grant an extra attempt.
+- B4c+) [ADDITION] If the judge forgot to put a sight blocker (or did not put it immediately), the WCA Delegate should always grant an extra attempt.
 - B4c++) [ADDITION] If the WCA Delegate does not suspect any infraction of the regulations by the competitor, the original attempt may stand.
 
 


### PR DESCRIPTION
Adds Guideline B4c+ based on the recent rulings.

Completely unsure about the wording and don't like the fact it looks almost the same as the [guideline](https://www.worldcubeassociation.org/regulations/guidelines.html#A2d1++) about scramble signatures thus making it look to have the same level of importance.