### PR TITLE
Clarify A7g

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -437,7 +437,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - A7c4) The competitor should not sign an attempt before the judge has recorded and signed the attempt. The competitor is ultimately responsible for ensuring that they and the judge have signed an attempt. If an attempt is found to be missing one or both signatures after the judge delivered the score sheet to the score taker (see [Regulation A7f](regulations:regulation:A7f)), it will be considered unfinished (DNF).
         - A7c5) Missing signatures found before the end of the competition may be added by the judge and/or the competitor, at the discretion of the WCA Delegate.
     - A7f) When a competitor's score sheet for a round is complete, the judge delivers the score sheet to the score taker.
-    - A7g) At the discretion of the WCA Delegate, an incident or penalty caused by a new competitor's inexperience may be replaced with an extra attempt.
+    - A7g) At the discretion of the WCA Delegate, an incident or penalty caused by the competitor's inexperience may be replaced with an extra attempt.
 
 
 ## <article-B><blindfolded><blindfoldedsolving> Article B: Blindfolded Solving


### PR DESCRIPTION
Make it clear that the competitor does not have to be new, but just has to be inexperienced (which opens up extras for other situations like competing in new events)