### PR TITLE
Pushing clock pins in inspection is +2

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -208,6 +208,12 @@ To be more informative, each Guideline is classified using one of the following 
 - E3d++) [CLARIFICATION] Competitors should not consider a personal stopwatch or watch as the official time, and must submit their solution when the judge calls "STOP".
 
 
+## <article-F><clock><clocksolving> Article F: Clock Solving
+
+- F3a+) [CLARIFICATION] One time penalty is assigned for each pin moved before the start of the solve. For example, if the competitor moves 3 pins before the start of the solve, 3 time penalties are assigned.
+- F3a++) [CLARIFICATION] If the same pin is moved multiple times, only one time penalty is assigned for that pin.
+
+
 ## <article-H><multiple-blindfolded><multipleblindfoldedsolving> Article H: Multi-Blind Solving
 
 - H1+) [ADDITION] If a puzzle with a duplicate scramble is found during an attempt, the puzzle may be re-scrambled using a different scramble sequence, at the discretion of the WCA Delegate.

--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -210,8 +210,8 @@ To be more informative, each Guideline is classified using one of the following 
 
 ## <article-F><clock><clocksolving> Article F: Clock Solving
 
-- F3a+) [CLARIFICATION] One time penalty is assigned for each pin moved before the start of the solve. For example, if the competitor moves 3 pins before the start of the solve, 3 time penalties are assigned.
-- F3a++) [CLARIFICATION] If the same pin is moved multiple times, only one time penalty is assigned for that pin.
+- F3a+) [CLARIFICATION] Time penalties are not cumulative. For example, if multiple pins are pushed during inspection, only one time penalty is assigned.
+- F3a++) [CLARIFICATION] Pins must not be turned during inspection. Penalty: disqualification of the attempt (DNF).
 
 
 ## <article-H><multiple-blindfolded><multipleblindfoldedsolving> Article H: Multi-Blind Solving

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -516,7 +516,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - F2a) The organization team may enforce using a stand for the puzzle to prevent it from falling before the start of the attempt. If such stands are used, the organization team should make an announcement before the round starts.
         - F2a1) The judge must remove the stand from the mat immediately after the competitor removes the puzzle from it.
 - F3) At the end of the inspection period, the competitor places the puzzle in a standing position. Penalty: disqualification of the attempt (DNF).
-    - F3a) The competitor must not change the positions of any pins from their scrambled positions before the start of the solve. Penalty: disqualification of the attempt (DNF).
+    - F3a) The competitor must not change the positions of any pins from their scrambled positions before the start of the solve. Penalty: time penalty (+2 seconds).
 
 
 ## <article-H><multiple-blindfolded><multipleblindfoldedsolving> Article H: Multi-Blind Solving


### PR DESCRIPTION
Assigning a DNF for this is overly harsh. Pushing a clock pin (or multiple pins) does not allow the competitor to see further into the solve the same way that turning a layer in other puzzles does, or that turning a clock dial does. Additionally, clock pins are easy to accidentally push compared to turning clock dials or turning layers on other puzzles. It is hard to see an instance where this could be abused. That is, there will never be a situation when it is “worth it” to move a pin during inspection and take the +2. Even someone who does not know how to solve a clock can easily push all 4 pins in under 2 seconds.

The only oddity with this proposal is that, if a competitor does accidentally push a pin during inspection, they would then be inclined to move all pins to their preferred locations. However, a solution to this would be to assign a +2 for EACH pin the competitor pushes during inspection. For example, if a competitor pushes three pins in inspection, they would be assigned three +2 penalties. (Although if the SAME pin is pushed multiple times, this does not incur multiple penalties.)

The last part does not have to be implemented and it is also a possibility to simply assign one +2 for any number of pins pushed during inspection.