### PR TITLE
2k6 "expectation" -> "intention"

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -100,7 +100,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 2k3) Behaves in a way that is unlawful/violent/indecent/unsafe, or intentionally damages venue facilities or personal property within the venue.
     - 2k4) Distracts or interferes with others during the competition.
     - 2k5) Fails to abide by WCA Regulations during the competition.
-    - 2k6) Does not fulfill the event's requirements (e.g. not knowing how to solve the puzzle). A competitor must not compete with the expectation of a DNF result or an intentionally poor result.
+    - 2k6) Does not fulfill the event's requirements (e.g. not knowing how to solve the puzzle). A competitor must not compete with the intention of a DNF result or an intentionally poor result.
 - 2l) A competitor may be disqualified immediately, or after a warning, depending on the nature and severity of the infraction.
     - 2l1) A disqualified competitor is not eligible for the refund of any expenses due to participating in the competition.
 - 2n) Competitors may verbally dispute a ruling to the WCA Delegate.


### PR DESCRIPTION
I've always thought the word "expectation" doesn't really fit here. If someone is competing in 5BLD, they would probably "expect" to get a DNF, simply because the global DNF rate for the event is about 80%. If taken literally, this regulation would prevent competitors from competing an any event where they have a more than 50% DNF rate. Using the word "intention" is more logical and better fulfills the intent of the regulation.