### PR TITLE
Broaden 2a3

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -63,7 +63,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 2a) Any person may compete in a WCA competition if they:
     - 2a1) Comply with WCA Regulations.
     - 2a2) Meet the competition requirements, which must be clearly announced before the competition.
-    - 2a3) Are not suspended from participation by the WCA Board, WCA Disciplinary Committee, or WCA Ethics Committee.
+    - 2a3) Are not suspended from participation by the WCA.
     - 2a4) Comply with all reasonable safety measures deemed necessary by the WCA Delegate, which must be clearly announced before the competition.
 - 2b) Competitors below the age of 18 must obtain consent from their parent(s)/guardian(s) to register and compete.
 - 2c) Competitors register by providing all information required by the organization team (including: name, country, date of birth, gender, contact information, selected events).

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -63,7 +63,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
 - 2a) Any person may compete in a WCA competition if they:
     - 2a1) Comply with WCA Regulations.
     - 2a2) Meet the competition requirements, which must be clearly announced before the competition.
-    - 2a3) Are not suspended by the WCA Board.
+    - 2a3) Are not suspended from participation by the WCA Board, WCA Disciplinary Committee, or WCA Ethics Committee.
     - 2a4) Comply with all reasonable safety measures deemed necessary by the WCA Delegate, which must be clearly announced before the competition.
 - 2b) Competitors below the age of 18 must obtain consent from their parent(s)/guardian(s) to register and compete.
 - 2c) Competitors register by providing all information required by the organization team (including: name, country, date of birth, gender, contact information, selected events).


### PR DESCRIPTION
Under [this](https://www.worldcubeassociation.org/documents/motions/15.2022.1%20-%20Suspensions%20and%20other%20Sanctions.pdf) Motion both WEC (clause 6.1) and WDC (clauses 1.3 and 1.6) have the rights to suspend a person from participating in a WCA Competition, but the Regulations only mention the Board (Board does have this right as well as per [their](https://www.worldcubeassociation.org/documents/motions/04.2022.1%20-%20WCA%20Board.pdf) Motion clause 2.6).