### PR TITLE
Uppercase Clock (fix)

### DIFF
--- a/wca-guidelines.md
+++ b/wca-guidelines.md
@@ -93,8 +93,8 @@ To be more informative, each Guideline is classified using one of the following 
 - 4d++) [ADDITION] It is permitted for the puzzle to change its orientation when it is moved from the scrambler to the solving station, as long as no one is attempting to influence the randomness of the orientation (see [Regulation A2e1](regulations:regulation:A2e1)).
 - 4f+) [RECOMMENDATION] The WCA Delegate should generate sufficient scramble sequences for the entire competition ahead of time, including spare scramble sequences for extra attempts.
 - 4f++) [REMINDER] If the WCA Delegate generates any additional scramble sequences during the competition, the scramble sequences must be saved.
-- 4g2+) [CLARIFICATION] The scrambler must still verify that the clock is scrambled correctly.
-- 4g2++) [CLARIFICATION] If the clock falls over during uncovering, an extra must be given.
+- 4g2+) [CLARIFICATION] The scrambler must still verify that the Clock is scrambled correctly.
+- 4g2++) [CLARIFICATION] If the Clock falls over during uncovering, an extra must be given.
 - 4g2+++) [RECOMMENDATION] The scrambler should leave score sheets outside the cube cover instead of placing them inside the cube cover.
 
 

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -134,7 +134,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 3h3) Any modifications to a puzzle that result in poor performance by a competitor are not grounds for additional attempts.
     - 3h4) For Clock, the following modifications are permitted:
         - 3h4a) Customs "inserts" (the same shape and size as the traditional paper inserts) are permitted, at the discretion of the WCA Delegate. The inserts must have a clear indication of 12 o'clock that matches the original inserts.
-        - 3h4b) Puzzle design customizations that do not give an unfair advantage may be permitted, at the discretion of the WCA Delegate (e.g. checkerboard pattern clocks, faces with a custom design, tape on the side of the clock).
+        - 3h4b) Puzzle design customizations that do not give an unfair advantage may be permitted, at the discretion of the WCA Delegate (e.g. checkerboard pattern clocks, faces with a custom design, tape on the side of the Clock).
         - 3h4c) Customizations which distinguish pins from other pins of the same side are permitted, at the discretion of the WCA Delegate.
         - 3h4d) Logos anywhere on the puzzle, as long as the inner clock faces remain uncovered.
     - 3h5) On Clock, loose pins (i.e. pins that can toggle or recede using gravity instead of being directly pressed) are not considered reasonable wear, and these puzzles must not be permitted.


### PR DESCRIPTION
Small fix to uppercase `clock` where needed.

Closes #1100.