### PR TITLE
Remove the blindfolded logo restriction

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -147,7 +147,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 3k2) Penalty for attempts done with puzzles which are not permitted: disqualification of the attempt (DNF). The following exceptions apply:
         - 3k2a) If a non-permitted puzzle is found before a round is complete, affected results in the round may be replaced with extra attempts, at the discretion of the WCA Delegate.
         - 3k2b) 3x3x3 Multi-Blind: if any puzzles are found to be non-permitted, such puzzles may be individually counted as unsolved (without disqualifying the entire attempt), at the discretion of the WCA Delegate.
-- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo. Exception: For blindfolded events, a puzzle must not have a logo.
+- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo. Exception: For blindfolded events, a puzzle may only have a logo that is not detectable by touch.
     - 3l1) The logo must be placed on a center piece. Exceptions for puzzles that do not have center pieces:
         - 3l1a) For Pyraminx and 2x2x2, the logo may be on any piece.
         - 3l1b) For Square-1, the logo must be on a piece in the equatorial slice.

--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -147,7 +147,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 3k2) Penalty for attempts done with puzzles which are not permitted: disqualification of the attempt (DNF). The following exceptions apply:
         - 3k2a) If a non-permitted puzzle is found before a round is complete, affected results in the round may be replaced with extra attempts, at the discretion of the WCA Delegate.
         - 3k2b) 3x3x3 Multi-Blind: if any puzzles are found to be non-permitted, such puzzles may be individually counted as unsolved (without disqualifying the entire attempt), at the discretion of the WCA Delegate.
-- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo. Exception: For blindfolded events, a puzzle may only have a logo that is not detectable by touch.
+- 3l) A puzzle may have a logo on a colored part. If it does, it must have at most one colored part with a logo.
     - 3l1) The logo must be placed on a center piece. Exceptions for puzzles that do not have center pieces:
         - 3l1a) For Pyraminx and 2x2x2, the logo may be on any piece.
         - 3l1b) For Square-1, the logo must be on a piece in the equatorial slice.


### PR DESCRIPTION
A logo on a center piece only impacts blindfolded solving if the logo can be detected while blindfolded, which means it is either engraved, a sticker, or otherwise changing the texture of that center piece. If the logo is smoothly part of the plastic with no detectable texture/elevation changes, then it does not provide additional information while blindfolded.

There are two main options, since allowing only undetectable logos is regarded as non-viable:
1. Allowing all logos in blind. Consider dropping your cube during blind: a competitor with a touch detectable logo can restore their orientation with 25% odds as compared to 4% odds without a touch detectable logo (quick maths, I'm tired). If all logos are allowed, it's on the competitor to use a cube with a detectable logo to maximize this advantage in the case of a cube drop. This has many pros, as stated by Edward: being nice to people, ease of enforcement, better availability of hardware, avoids damage caused by removing logos. Note: this also impacts MBLD in addition to cube drops, since puzzles are picked up from table while blind.

2. Close this PR: no logos allowed, cube drop recovery chance stays at 4%. The main pros are that it's also easily enforceable and that it maintains the true integrity of blind solving, but has cons that mirror the pros of option 1.