### PR TITLE
Remove 2i3

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -88,7 +88,6 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - 2i2) Competitors may use cameras at the solving station at the discretion of the WCA Delegate, but the following restrictions apply from the start of the attempt until the competitor stops the solve. Penalty for breaking a restriction: disqualification of the attempt (DNF).
         - 2i2a) Each camera monitor must be blank or out of sight of the competitor (see [Regulation A5b](regulations:regulation:A5b)).
         - 2i2b) The competitor must not use (e.g. operate, wear) any active camera. Exception: the competitor may wear a camera mounted on their head, as long as it is out of their sight and it is clear that they are not interacting with it (apart from wearing it).
-    - 2i3) The competitor may have a cell phone in their pocket, as long as it is clear that they are not otherwise interacting with it.
     - 2i4) Competitors should turn off all cell phone notifications while competing to avoid disturbing the competition.
 - 2j) The WCA Delegate may disqualify a competitor from specific attempts and/or events.
     - 2j1) If a competitor is disqualified from an event for any reason, they are not eligible for any more attempts in the event.


### PR DESCRIPTION
Given that it is now legal to *interact* with a device as long as it is clear that the competitor is not using it, 2i3 is not really necessary anymore.

Closes #1158. (Incompatible).