### PR TITLE
Clarify E3b

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -517,7 +517,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - E2e1) The WCA Delegate may ask the competitor to explain the purpose of each move in their solution, irrespective of the scramble sequence. If the competitor cannot give a valid explanation, the attempt is disqualified (DNF).
 - E3) The competitor may use the following objects during the attempt. Penalty for using unauthorized objects: disqualification of the attempt (DNF).
     - E3a) Paper (supplied by the judge), the solution sheet (supplied by the judge), a picture of the scramble for that attempt (which may be included on the paper or solution sheet), and pens/pencils or similar (supplied by the judge, or optionally self-supplied).
-    - E3b) 3x3x3 Cubes (at most 3, self-supplied), as described in [Article 3](regulations:article:3).
+    - E3b) 3x3x3 Cubes (at most 3, self-supplied), which must be as described in [Article 3](regulations:article:3) before starting the attempt.
     - E3c) Stickers (self-supplied).
     - E3d) Stopwatch or watch (self-supplied) for keeping track of the elapsed time, if it is approved by the WCA Delegate.
     - E3e) Other non-electronic aids that do not give an unfair advantage, at the discretion of the WCA Delegate (see [Regulation 2i1](regulations:regulation:2i1)).


### PR DESCRIPTION
In Fewest Moves, the puzzles must not have any marking _before_ the attempt, but the competitor may use stickers (for example) _during_ the attempt.