### PR TITLE
Alternate fix of inspection timeframe

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -416,8 +416,8 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
     - A4b) The competitor uses their fingers to touch the elevated sensor surfaces of the Stackmat timer. The competitor's palms must be facing down, and located on the side of the timer that is closer to the competitor. Penalty: time penalty (+2 seconds).
         - A4b1) The competitor must have no physical contact with the puzzle while starting the solve. Penalty: time penalty (+2 seconds).
     - A4d) If a Stackmat timer is in use, the competitor should keep their hands on the timer until they see a green timer light. They start the solve by removing their hands from the timer (thus starting the timer).
-        - A4d1) The competitor must start the solve within 15 seconds of the start of the inspection. Penalty: time penalty (+2 seconds).
-        - A4d2) The competitor must start the solve within 17 seconds of the start of the inspection. Penalty: disqualification of the attempt (DNF).
+        - A4d1) The competitor must start the solve no later than 15 seconds from the start of the inspection. Penalty: time penalty (+2 seconds).
+        - A4d2) The competitor must start the solve no later than 17 seconds from the start of the inspection. Penalty: disqualification of the attempt (DNF).
         - A4d3) If a stopwatch is in use, the judge starts the stopwatch as soon as the competitor starts the solve.
     - A4e) Time penalties for starting the solve are cumulative.
 - A5) During the solve:


### PR DESCRIPTION
Same idea as #1166, would implement one or the other. This one has 15.00 seconds of inspection as no penalty