### PR TITLE
Automatically deploy WCA-Regulations to S3

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install wrc
         # install wkhtmltopdf
-        wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O wkhtml.tar.xz && tar -xf wkhtml.tar.xz --strip-components=1 -C /usr/local
+        wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O wkhtml.tar.xz && sudo tar -xf wkhtml.tar.xz --strip-components=1 -C /usr/local
     - name: Deploy to S3
       run: |
         outputdir=/tmp/regulations

--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -24,7 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install wrc
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         # install wkhtmltopdf
         wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O wkhtml.tar.xz && tar -xf wkhtml.tar.xz --strip-components=1 -C /usr/local
     - name: Deploy to S3

--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -36,4 +36,4 @@ jobs:
         # Update version
         git_hash=$(git rev-parse --short "$GITHUB_SHA")
         echo "$git_hash" > $outputdir/version
-        aws s3 sync $outputdir s3://wca-regulations/
+        aws s3 sync $outputdir s3://wca-regulations/ --acl public-read

--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -3,6 +3,7 @@ name: Deploy To S3
 on:
   push:
     branches: [ official ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -1,0 +1,39 @@
+name: Deploy To S3
+
+on:
+  push:
+    branches: [ official ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install wrc
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # install wkhtmltopdf
+        wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O wkhtml.tar.xz && tar -xf wkhtml.tar.xz --strip-components=1 -C /usr/local
+    - name: Deploy to S3
+      run: |
+        outputdir=/tmp/regulations
+        mkdir -p $outputdir
+        wrc --target=json -o $outputdir .
+        wrc --target=html -o $outputdir .
+        wrc --target=pdf -o $outputdir .
+        # Update version
+        git_hash=$(git rev-parse --short "$GITHUB_SHA")
+        echo "$git_hash" > $outputdir/version
+        aws s3 sync $outputdir s3://wca-regulations/


### PR DESCRIPTION
Due to infrastructure changes we will deploy wca-regulations directly to S3 and serve them from there. These will automatically update on the website when the version file changes