### PR TITLE
Compile merged Regulations and Guidelines

### DIFF
--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -33,6 +33,7 @@ jobs:
         git_hash=$(git rev-parse --short "$GITHUB_SHA")
         wrc --target=json -g $git_hash -o $outputdir .
         wrc --target=html -g $git_hash -o $outputdir .
+        wrc --target=html --merged -g $git_hash -o $outputdir .
         wrc --target=pdf -g $git_hash -o $outputdir .
         # Update version
         echo "$git_hash" > $outputdir/version


### PR DESCRIPTION
Add html with the merged flag.

The new option generates a `full.html.erb` file in the output dir. So now we have three html files, two for the separated documents and one for the merged version.

See https://github.com/thewca/worldcubeassociation.org/pull/9541 and https://github.com/thewca/wca-regulations-compiler/pull/28.