### PR TITLE
Add Action to Move Current Regulations to History (#1191)

### DIFF
--- a/.github/workflows/cycle-regulations.yml
+++ b/.github/workflows/cycle-regulations.yml
@@ -1,0 +1,28 @@
+name: Move Regulations to History
+
+on:
+  workflow_dispatch:
+    inputs:
+      folder_name:
+        required: true
+        description: The name of the sub folder to move the regulations to, usually the date the regulations come out like '2023-08-01'
+
+jobs:
+  move:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.CI_CD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CI_CD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Move current version to the history
+        run: |
+          aws s3 cp s3://wca-regulations/index.html.erb ./input.html.erb
+          # Add info about it not being the official version
+          sed -E 's/<br\/>/\<br\>\<b\>This is NOT the current official version\<\/b\>\<br\>/g' ./input.html.erb > ./index.html.erb
+          aws s3 cp ./index.html.erb s3://wca-regulations/history/official/${{ github.event.inputs.folder_name }}/index.html.erb --acl public-read
+          aws s3 cp s3://wca-regulations/guidelines.html.erb s3://wca-regulations/history/official/${{ github.event.inputs.folder_name }}/guidelines.html.erb --acl public-read
+          aws s3 cp s3://wca-regulations/wca-regulations-and-guidelines.pdf s3://wca-regulations/history/official/${{ github.event.inputs.folder_name }}/wca-regulations-and-guidelines.pdf --acl public-read

--- a/.github/workflows/deploy-to-s3.yml
+++ b/.github/workflows/deploy-to-s3.yml
@@ -39,3 +39,9 @@ jobs:
         # Update version
         echo "$git_hash" > $outputdir/version
         aws s3 sync $outputdir s3://wca-regulations/ --acl public-read
+        # Copy over the current latest version to history
+        date_str=$(cat $outputdir/index.html.erb | grep -oP 'Version: \K[A-Za-z]+ \d{1,2}, \d{4}')
+        formatted_date=$(date -d "$date_str" +"%Y-%m-%d")
+        aws s3 cp s3://wca-regulations/guidelines.html.erb s3://wca-regulations/history/official/$formatted_date/guidelines.html.erb --acl public-read
+        aws s3 cp s3://wca-regulations/wca-regulations-and-guidelines.pdf s3://wca-regulations/history/official/$formatted_date/wca-regulations-and-guidelines.pdf --acl public-read
+        aws s3 cp s3://wca-regulations/index.html.erb s3://wca-regulations/history/official/$formatted_date/index.html.erb --acl public-read


### PR DESCRIPTION
This should be triggered before a new regulations cycle. It can be then linked to in [the history
file](https://github.com/thewca/worldcubeassociation.org/blob/master/WcaOnRails/app/views/regulations/history.html.erb)