### PR TITLE
Hotfix for rounded averages in 9f2

### DIFF
--- a/wca-regulations.md
+++ b/wca-regulations.md
@@ -249,7 +249,7 @@ Note: Because Article and Regulation numbers are not reassigned when Regulations
         - 9b5b) Cutoff formats for this event: "Best of X" (where X is 1 or 2) cutoff phase for "Best of Y" (where Y is 2 or 3, and Y > X).
 - 9f) The results of a round are measured as follows:
     - 9f1) All timed results under 10 minutes, except for 3x3x3 Multi-Blind, are measured and truncated to hundredths of a second. All timed averages and means under 10 minutes are measured and rounded to the nearest hundredth of a second.
-    - 9f2) All timed results, averages, and means over 10 minutes, as well as all times for 3x3x3 Multi-Blind results, are measured and truncated to seconds.
+    - 9f2) All timed results over 10 minutes, as well as all times for 3x3x3 Multi-Blind results, are measured and truncated to seconds. All timed averages and means over 10 minutes are measured and rounded to the nearest second (e.g. X.49 becomes X, X.50 becomes X+1).
     - 9f4) The result of an attempt is recorded as DNF (Did Not Finish) if the attempt is disqualified or unsolved/unfinished.
         - 9f4a) If a competitor violates a regulation clearly enough that the attempt is certain to be disqualified, the judge should immediately stop the attempt. If the judge is uncertain or a dispute could be disruptive (e.g. because an extra attempt could delay the competition), the judge should consult the WCA Delegate.
     - 9f5) The result of an attempt is recorded as DNS (Did Not Start) if the competitor was eligible for the attempt and did not start it (see [Regulation A3b2](regulations:regulation:A3b2)).


### PR DESCRIPTION
9f2 was amended for the [2025-01-01 Regulations release](https://www.worldcubeassociation.org/posts/wca-regulations-january-2025) to replace rounding with truncation. The motivation behind that change was driven by individual results. Justification and [documentation](https://docs.google.com/document/d/1q0XkRuSz-Nxy9BFcXSkzNLLl6D7u3_2VHhU_w_Pokyw/edit?tab=t.0#heading=h.dok73dr9asz1) for the change focused on individual results, and did not discuss means and averages.

The [updated wording](https://github.com/thewca/wca-regulations/pull/1259/files) changed 9f2 from rounding to truncation for both single results and means and averages. Following [software implementation](https://github.com/thewca/wca-live/issues/253), the change for means and averages was considered undesirable, as it results in averages and means being calculated differently depending on when they were achieved.

Since the undesired change was not fully intended, and did not form part of the justification presented to Staff and the Community, an out-of-cycle hotfix is considered appropriate. The proposed wording is based closely on the previous Regulations and does not introduce other changes. 